### PR TITLE
refactor Dockerfile to use new base image with dependencies

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,33 +1,28 @@
-FROM ubuntu:16.04
-MAINTAINER EdgeX Foundry <edgex-devel@lists.edgexfoundry.org>
+FROM nexus3.edgexfoundry.org:10003/edgex-docs-builder:latest
 
-# Install software to build docs
+ARG STREAM=master
 
-RUN apt-get update
-RUN apt-get install -y git python-pip latexmk texlive-latex-recommended \
-  texlive-latex-extra texlive-fonts-recommended nodejs npm make linkchecker \
-  wget
-RUN apt-get install -y git python-pip latexmk nodejs npm make linkchecker curl
-RUN apt-get install -y --no-install-recommends texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
-RUN ln -s /usr/bin/nodejs /usr/bin/node
-RUN pip install sphinx==1.7.9 sphinxcontrib-googleanalytics==0.1
-RUN npm i -g raml2html@3.0.1
+ENV RAML_FILES="core-data.raml \
+  core-metadata.raml \
+  core-command.raml \
+  support-logging.raml \
+  support-scheduler.raml \
+  support-notifications.raml \
+  export-client.raml \
+  system-agent.raml"
+
+ENV RAML_URL="https://raw.githubusercontent.com/edgexfoundry/edgex-go/${STREAM}/api/raml"
+
 RUN mkdir docbuild
 WORKDIR /docbuild
 
-RUN mkdir ./_templates/
-COPY _templates ./_templates
+# Templates not ready yet.
+# RUN mkdir ./_templates/
+# COPY _templates ./_templates
 
 # Download service RAML files 
 
-RUN curl -s https://raw.githubusercontent.com/edgexfoundry/edgex-go/edinburgh/api/raml/core-data.raml -o ./core-data.raml
-RUN curl -s https://raw.githubusercontent.com/edgexfoundry/edgex-go/edinburgh/api/raml/core-metadata.raml -o ./core-metadata.raml
-RUN curl -s https://raw.githubusercontent.com/edgexfoundry/edgex-go/edinburgh/api/raml/core-command.raml -o ./core-command.raml
-RUN curl -s https://raw.githubusercontent.com/edgexfoundry/edgex-go/edinburgh/api/raml/support-logging.raml -o ./support-logging.raml
-RUN curl -s https://raw.githubusercontent.com/edgexfoundry/edgex-go/edinburgh/api/raml/support-scheduler.raml -o ./support-scheduler.raml
-RUN curl -s https://raw.githubusercontent.com/edgexfoundry/edgex-go/edinburgh/api/raml/support-notifications.raml -o ./support-notifications.raml
-RUN curl -s https://raw.githubusercontent.com/edgexfoundry/edgex-go/edinburgh/api/raml/export-client.raml -o ./export-client.raml
-RUN curl -s https://raw.githubusercontent.com/edgexfoundry/edgex-go/edinburgh/api/raml/system-agent.raml -o ./system-agent.raml
+RUN for file in ${RAML_FILES}; do echo "${RAML_URL}/${file}" && curl -s ${RAML_URL}/${file} -o ./${file}; done
 
 # Clone documentation sources in other repositories
 
@@ -62,7 +57,6 @@ COPY walk-through ./
 COPY quick-start ./
 COPY security/* ./
 COPY application/* ./
-
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/build.sh
+++ b/build.sh
@@ -2,13 +2,14 @@
 set -e
 
 # Build image (copying in documentation sources)
+# default to master branch, can be overriden
+build_stream=${1:-master}
 
-docker build -t doc-builder:latest -f Dockerfile.build .
+docker build -t doc-builder:latest -f Dockerfile.build --build-arg STREAM=${build_stream} .
 rm -rf _build
 mkdir _build
 
 # Build documentation in container
-
 docker run --rm -v "$(pwd)"/_build:/docbuild/_build doc-builder:latest
 
 


### PR DESCRIPTION
This PR refactors the two following things:

1. `Dockerfile.build` - now uses the base image: `nexus3.edgexfoundry.org:10003/edgex-docs-builder:latest` in the `FROM` statement. This base image has all the dependencies need to build all the documentation. This should speed up the Jenkins builds on the significantly. I also attempted to minimize the number of layers in the builder image as much as I could.
2. `build.sh`-  now accepts an argument for the "stream". This allows ties into what RAML files are pulled from github.com. You can see that on line #25. The default "stream" is master, so if you wanted to build the `edinburgh` stream, you would run:

```
$ ./build.sh edinburgh
```

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>