### PR TITLE
Update Docker Compose-file Locations

### DIFF
--- a/examples/Ch-ExamplesAddingMQTTDevice.rst
+++ b/examples/Ch-ExamplesAddingMQTTDevice.rst
@@ -322,7 +322,7 @@ Create the configuration file, named configuration.toml, as shown below replacin
 Add Device Service to docker-compose File (docker-compose.yml)
 --------------------------------------------------------------
 
-Download the docker-compose file from https://github.com/edgexfoundry/developer-scripts/blob/master/compose-files/docker-compose-edinburgh-1.0.0.yml.
+Download the docker-compose file from https://github.com/edgexfoundry/developer-scripts/blob/master/releases/edinburgh/compose-files/docker-compose-edinburgh-1.0.0.yml.
 
 Because we deploy EdgeX using docker-compose, we must add device-mqtt to the docker-compose file. If you have prepared configuration files, you can mount them using volumes and change the entrypoint for device-mqtt internal use.
 

--- a/examples/Ch-ExamplesAddingModbusDevice.rst
+++ b/examples/Ch-ExamplesAddingModbusDevice.rst
@@ -200,7 +200,7 @@ You can download and use the provided :download:`EdgeX_ExampleModbus_configurati
 Add Device Service to docker-compose File
 -----------------------------------------
 
-Because we deploy EdgeX using docker-compose, we must add the device-modbus to the docker-compose file ( https://github.com/edgexfoundry/developer-scripts/blob/master/compose-files/docker-compose-delhi-0.7.0.yml ). If you have prepared configuration files, you can mount them using volumes and change the entrypoint for device-modbus internal use.
+Because we deploy EdgeX using docker-compose, we must add the device-modbus to the docker-compose file ( https://github.com/edgexfoundry/developer-scripts/blob/master/releases/delhi/compose-files/docker-compose-delhi-0.7.0.yml ). If you have prepared configuration files, you can mount them using volumes and change the entrypoint for device-modbus internal use.
 
     .. image:: config_changes.png
         :scale: 50%

--- a/examples/Ch-ExamplesAddingSNMPDevice.rst
+++ b/examples/Ch-ExamplesAddingSNMPDevice.rst
@@ -46,7 +46,7 @@ Postman (Linux 64bit)
 
 EdgeX - barcelona-docker-compose.yaml
 
--- https://github.com/edgexfoundry/developer-scripts/blob/master/docker-compose.yml
+-- https://github.com/edgexfoundry/developer-scripts/blob/master/releases/barcelona/compose-files/docker-compose-barcelona-0.2.1.yml
 
 **SNMP - Device documentation**
 

--- a/getting-started/Ch-GettingStartedUsers.rst
+++ b/getting-started/Ch-GettingStartedUsers.rst
@@ -58,7 +58,7 @@ If you know Docker and understand the architecture of EdgeX Foundry and its micr
 
 Getting and running EdgeX Foundry microservices can also be accomplished more easily provided you have the Docker Compose file that specifies to Docker/Docker Compose which containers you want, and how you want to run those containers. The EdgeX Foundry development team provides you with Docker Compose files for each release through the EdgeX Foundry GitHub repository. To obtain and run EdgeX Foundry, visit the project GitHub and download (or copy the contents) of the EdgeX Foundry Docker Compose file suitable to the version you wish to use - to a local directory.
 
-The collection of the EdgeX Foundry Docker compose files are found here:  https://github.com/edgexfoundry/developer-scripts/tree/master/compose-files
+The collection of the EdgeX Foundry Docker compose files are found here:  https://github.com/edgexfoundry/developer-scripts/tree/master/releases
 
 Note that most of the Docker Compose files carry a specific version identifier (like california-0.6.0) in the file name.  These Compose files help obtain the specific version of EdgeX.  The docker-compose.yml file will pull the latest tagged EdgeX microservices from Docker Hub.  The docker-compose-nexus.yml will pull the latest microservice images from the developer's Nexus registry which contains the latest built artifacts.  These are typically work-in-progress microservice artifacts and should not be used by most end users.  It is recommended that you use the lastest version of EdgeX Foundry.  As of this writing, the latest version is: Delhi (version 0.7.1)
 

--- a/getting-started/Ch-GettingStartedUsersNexus.rst
+++ b/getting-started/Ch-GettingStartedUsersNexus.rst
@@ -22,7 +22,7 @@ $ docker pull nexus3.edgexfoundry.org:10004/docker-core-config-seed
 
 **Replace the image(s) in docker-compose.yml**
 
-A Docker Compose file that pulls the latest EdgeX container images from Nexus is available here:  https://github.com/edgexfoundry/developer-scripts/blob/master/compose-files/docker-compose-nexus.yml.
+A Docker Compose file that pulls the latest EdgeX container images from Nexus is available here:  https://github.com/edgexfoundry/developer-scripts/blob/master/releases/nightly-build/compose-files/docker-compose-nexus.yml.
 If you are creating your own Docker Compose file or want to use and existing EdgeX Docker Compose file but selectively use Nexus images, replace the name/location of the Docker image in your docker-compose.yml file for the containers you want to get from Nexus versus Docker Hub.  For example, the config-seed item in docker-compose.yml might ordinarily look like this:
 
 ::

--- a/quick-start/Ch-QuickStart.rst
+++ b/quick-start/Ch-QuickStart.rst
@@ -18,7 +18,7 @@ The fastest way to start running EdgeX is by using our pre-built Docker images. 
 Running EdgeX
 =============
 
-Once you have Docker and Docker Compose installed, you need the configuration file for downloading and running the EdgeX Foundry docker containers. Download the `latest docker-compose file here <https://github.com/edgexfoundry/developer-scripts/raw/master/compose-files/docker-compose-delhi-0.7.1.yml>`_ and save this as ``docker-compose.yml`` in your local directory. This file contains everything you need to deploy EdgeX with docker.
+Once you have Docker and Docker Compose installed, you need the configuration file for downloading and running the EdgeX Foundry docker containers. Download the `latest docker-compose file here <https://github.com/edgexfoundry/developer-scripts/raw/master/releases/delhi/compose-files/docker-compose-delhi-0.7.1.yml>`_ and save this as ``docker-compose.yml`` in your local directory. This file contains everything you need to deploy EdgeX with docker.
 
 First, use this command to download the EdgeX Foundry Docker images from Docker Hub::
 

--- a/security/Ch-APIGateway.rst
+++ b/security/Ch-APIGateway.rst
@@ -13,7 +13,7 @@ KONG (https://konghq.com/) is the product underlying the API gateway.  The EdgeX
 Start the API Gateway
 ======================
 
-Start the API gateway with Docker Compose and a Docker Compose manifest file (the Docker Compose file named docker-compose-delhi-0.7.0.yml found at https://github.com/edgexfoundry/developer-scripts/tree/master/compose-files/security)).  This Compose file starts all of EdgeX including the security services. The command to start EdgeX inclusive of API gateway related services is:
+Start the API gateway with Docker Compose and a Docker Compose manifest file (the Docker Compose file named docker-compose-delhi-0.7.0.yml found at https://github.com/edgexfoundry/developer-scripts/tree/master/releases/delhi/compose-files/security)).  This Compose file starts all of EdgeX including the security services. The command to start EdgeX inclusive of API gateway related services is:
 ::
 
     docker-compose up -d

--- a/security/Ch-SecretStore.rst
+++ b/security/Ch-SecretStore.rst
@@ -31,7 +31,7 @@ Start the Secret Store
 Start the Secret Store with Docker Compose and a Docker Compose manifest file. The Docker Compose file named docker-compose-delhi-0.7.0.yml can be found at these two locations:
 
     * https://github.com/edgexfoundry/security-secret-store/blob/delhi/docker-compose-delhi-0.7.0.yml
-    * https://github.com/edgexfoundry/developer-scripts/blob/master/compose-files/security/docker-compose-delhi-0.7.0.yml
+    * https://github.com/edgexfoundry/developer-scripts/blob/master/releases/delhi/compose-files/security/docker-compose-delhi-0.7.0.yml
 
 This Compose file starts the entire EdgeX Foundry platform including the security services.
 

--- a/walk-through/Ch-WalkthroughRunning.rst
+++ b/walk-through/Ch-WalkthroughRunning.rst
@@ -16,7 +16,7 @@ A Docker Compose file is a manifest file, which lists:
 * The order in which the containers should be started
 * The parameters under which the containers should be run
 
-It is recommended that you use the lastest version of EdgeX Foundry. As of this writing, the latest version can be found here: https://github.com/edgexfoundry/developer-scripts/raw/master/compose-files/docker-compose-delhi-0.7.1.yml
+It is recommended that you use the lastest version of EdgeX Foundry. As of this writing, the latest version can be found here: https://github.com/edgexfoundry/developer-scripts/raw/master/releases/delhi/compose-files/docker-compose-delhi-0.7.1.yml
 
 Save this file as ``docker-compose.yml`` in your working directory so that the following commands will find it.
 


### PR DESCRIPTION
https://github.com/edgexfoundry/developer-scripts/issues/128
restructured the edgexfoundry/developer-scripts /compose-files directory
into a /releases directory with release-specific subdirectories.

This commit updates the related website documentation references.

https://github.com/edgexfoundry/edgex-docs/issues/11
Signed-off-by: Michael W. Estrin <me@michaelestrin.com>