### PR TITLE
Post-implementation man page update for security-file-token-provider.

### DIFF
--- a/security/Ch-SecretStore.rst
+++ b/security/Ch-SecretStore.rst
@@ -1048,5 +1048,5 @@ See also
 
 Some of the command used in implementing security services have man-style documentation:
 
-* `token-file-provider <token-file-provider.1.html>`_  - Generate Vault tokens for EdgeX services
+* `security-file-token-provider <security-file-token-provider.1.html>`_  - Generate Vault tokens for EdgeX services
 * `security-secrets-setup <security-secrets-setup.1.html>`_  - Creates an on-device public-key infrastructure (PKI) to secure microservice secret management


### PR DESCRIPTION
Deltas:

 - Rename to security-file-token-provider
 - Change edgex-use-defaults to edgex_use_defaults
   to follow normal JS conventions
 - custom_policy is JSON object instead of array of objects
   to bring in line with JSON serialization format of HCL
 - Updated docs to reflect how display_name is tweaked by Vault
 - Added metadata to reflect service name as created by utility
   to be used by go-mod-secrets client as a URL hint

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>