### PR TITLE
Pin mkdocs-material to 4.6.3 and add recheck trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,9 @@ pipeline {
         quietPeriod(5) // wait a few seconds before starting to aggregate multiple commits into a single build
         durabilityHint 'PERFORMANCE_OPTIMIZED'
     }
+    triggers {
+        issueCommentTrigger('.*^recheck$.*')
+    }
     stages {
         stage('Build Docs') {
             agent {
@@ -18,7 +21,7 @@ pipeline {
             }
             steps {
                 sh 'pip install mkdocs'
-                sh 'pip install mkdocs-material'
+                sh 'pip install mkdocs-material==4.6.3'
                 sh 'mkdocs build'
 
                 // stash the site contents generated from mkdocs build


### PR DESCRIPTION
This PR fixes the current build issue after mkdocs-material release their 5.x version. A follow-on PR will be created to address the upgrade to mkdocs-material 5.x.

https://squidfunk.github.io/mkdocs-material/releases/5/#how-to-upgrade

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:

## What has been updated?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information