### PR TITLE
Correct the document links in Device Service page

### DIFF
--- a/docs_src/microservices/device/Ch-DeviceServices.md
+++ b/docs_src/microservices/device/Ch-DeviceServices.md
@@ -29,7 +29,7 @@ following microservice:
 
 > APIs\--Device Services\--Virtual Device Service
 
-**Device Service Requirements**
+**Device Service Functional Requirements**
 
 Requirements for the device service are provided below. These
 requirements are being used to define what functionality needs to be
@@ -38,13 +38,4 @@ scaffolding code. They may also help the reader understand the duties
 and role of a device service.
 
 [DS-SDK
-Requirements](https://wiki.edgexfoundry.org/display/FA/Architecture--Device+Services+Microservices?preview=/328052/4587926/DS-SDK-Requirements-v3.xlsx)
-
-**Device Service Design**
-
-Sequence Diagrams that outline the objects and process of each of the
-requirements.
-
-[Design for Requirements
-\#1-4](https://wiki.edgexfoundry.org/display/FA/Architecture--Device+Services+Microservices?preview=/328052/4588068/DS-SDK-Design-SequenceDiagrams.vsdx)
-
+Functional Requirements](https://wiki.edgexfoundry.org/download/attachments/329488/edgex-device-service-requirements-v11.pdf)


### PR DESCRIPTION
fix https://github.com/edgexfoundry/edgex-docs/issues/161
- modify the requirement document URL
- remove the section of sequence diagram

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #161

## What has been updated?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information