### PR TITLE
docs: fix a broken docker-compose link

### DIFF
--- a/docs_src/microservices/security/Ch-SecretStore.md
+++ b/docs_src/microservices/security/Ch-SecretStore.md
@@ -64,10 +64,9 @@ The key features of Vault are:
 
 Start the Secret Store with Docker Compose and a Docker Compose manifest
 file. The Docker Compose file named docker-compose-fuji.yml can be found
-at these two locations:
+here:
 
-> -   <https://github.com/edgexfoundry/security-secret-store/blob/fuji/docker-compose-fuji.yml>
-> -   <https://github.com/edgexfoundry/developer-scripts/blob/master/releases/fuji/compose-files/security/docker-compose-fuji.yml>
+> -   <https://github.com/edgexfoundry/developer-scripts/blob/master/releases/fuji/compose-files/docker-compose-fuji.yml>
 
 This Compose file starts the entire EdgeX Foundry platform including the
 security services.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
The link is broken 
![image](https://user-images.githubusercontent.com/697188/87091575-e887e080-c207-11ea-8e38-5d5f1e696c5b.png)

Issue Number:

## What has been updated?
The broken link :P

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information