### PR TITLE
Update docker-compose references to release Geneva

### DIFF
--- a/docs_src/examples/Ch-ExamplesAddingMQTTDevice.md
+++ b/docs_src/examples/Ch-ExamplesAddingMQTTDevice.md
@@ -324,8 +324,8 @@ replacing the host IP with your host address:
 
 ## Add Device Service to docker-compose File (docker-compose.yml)
 
-Download the docker-compose file from
-<https://github.com/edgexfoundry/developer-scripts/blob/master/releases/fuji/compose-files/docker-compose-fuji.yml>.
+Download the `Geneva` release docker-compose file from
+<https://github.com/edgexfoundry/developer-scripts/blob/master/releases/geneva/compose-files/docker-compose-geneva-redis.yml>.
 
 Because we deploy EdgeX using docker-compose, we must add device-mqtt to
 the docker-compose file. If you have prepared configuration files, you

--- a/docs_src/examples/Ch-ExamplesAddingModbusDevice.md
+++ b/docs_src/examples/Ch-ExamplesAddingModbusDevice.md
@@ -181,7 +181,7 @@ role="download"}.
 
 Because we deploy EdgeX using docker-compose, we must add the
 device-modbus to the docker-compose file (
-<https://github.com/edgexfoundry/developer-scripts/blob/master/releases/fuji/compose-files/docker-compose-fuji.yml>
+<https://github.com/edgexfoundry/developer-scripts/blob/master/releases/geneva/compose-files/docker-compose-geneva-redis.yml>
 ). If you have prepared configuration files, you can mount them using
 volumes and change the entrypoint for device-modbus internal use.
 

--- a/docs_src/microservices/security/Ch-SecretStore.md
+++ b/docs_src/microservices/security/Ch-SecretStore.md
@@ -63,13 +63,11 @@ The key features of Vault are:
 ## Start the Secret Store
 
 Start the Secret Store with Docker Compose and a Docker Compose manifest
-file. The Docker Compose file named docker-compose-fuji.yml can be found
-here:
+file. The whole set of Docker Compose files for Geneva release can be found here:
 
-> -   <https://github.com/edgexfoundry/developer-scripts/blob/master/releases/fuji/compose-files/docker-compose-fuji.yml>
+> -   <https://github.com/edgexfoundry/developer-scripts/blob/master/releases/geneva/compose-files>
 
-This Compose file starts the entire EdgeX Foundry platform including the
-security services.
+[The Compose file](https://github.com/edgexfoundry/developer-scripts/blob/master/releases/geneva/compose-files/docker-compose-geneva-redis.yml) starts the entire EdgeX Foundry platform with Redis including the security services.
 
 The command to start EdgeX Foundry platform including the Secret Store
 and API gateway related services is:

--- a/docs_src/walk-through/Ch-WalkthroughRunning.md
+++ b/docs_src/walk-through/Ch-WalkthroughRunning.md
@@ -22,7 +22,7 @@ A Docker Compose file is a manifest file, which lists:
 
 It is recommended that you use the lastest version of EdgeX Foundry. As
 of this writing, the latest version can be found here:
-<https://github.com/edgexfoundry/developer-scripts/raw/master/releases/fuji/compose-files/docker-compose-fuji.yml>
+<https://github.com/edgexfoundry/developer-scripts/raw/master/releases/geneva/compose-files/docker-compose-geneva-redis.yml>
 
 Save this file as `docker-compose.yml` in your working directory so that
 the following commands will find it.


### PR DESCRIPTION
  Fixes: #187

  Update documentation containing docker-compose file references from `Fuji` to `Geneva`

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #187 

## What has been updated?
- Change/update the documentation that has docker-compose references from release `Fuji` to release `Geneva`.


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
