### PR TITLE
build: upgrade docs to reference use of Go 1.15

### DIFF
--- a/docs_src/getting-started/Ch-GettingStartedGoDevelopers.md
+++ b/docs_src/getting-started/Ch-GettingStartedGoDevelopers.md
@@ -16,7 +16,7 @@ micro services.
 
 ### Go
 
-The open sourced micro services of EdgeX Foundry are written in Go 1.13.
+The open sourced micro services of EdgeX Foundry are written in Go 1.15.
 See <https://golang.org/dl/> for download and installation instructions.
 Newer versions of Go are available and may work, but the project has not
 built and tested to these newer versions of the language.


### PR DESCRIPTION
modified Go Developers guide to indicate project now uses Go 1.15

Fixes: #228
Signed-off-by: Jim White <jpwhite_mn@yahoo.com>

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
n/a - updated docs to indicate project uses Go 1.15

Issue Number: #228 

## What has been updated?
Ch-GettingStartedGoDevelopers.md

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information