### PR TITLE
feat(VirtualDeviceService): Add supported array value types

### DIFF
--- a/docs_src/microservices/device/virtual/Ch-VirtualDevice.md
+++ b/docs_src/microservices/device/virtual/Ch-VirtualDevice.md
@@ -11,10 +11,10 @@ when executing functional or performance tests without having any real devices.
 
 The virtual device service, built in Go and based on the device service Go SDK, can simulate sensors by generating data of the following data types:
 
-- Bool
-- Int8, Int16, Int32, Int64
-- Uint8, Uint16, Uint32, Uint64
-- Float32, Float64
+- Bool, BoolArray
+- Int8, Int16, Int32, Int64, Int8Array, Int16Array, Int32Array, Int64Array
+- Uint8, Uint16, Uint32, Uint64, Uint8Array, Uint16Array, Uint32Array, Uint64Array
+- Float32, Float64, Float32Array, Float64Array
 - Binary
 
 The virtual device services leverages [ql(an embedded SQL database engine)](https://godoc.org/github.com/cznic/ql) to simulate virtual resources.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: fix #248 

## What has been updated?
The following array value types are added into the introduction section:
- BoolArray
- Int8Array, Int16Array, Int32Array, Int64Array
- Uint8Array, Uint16Array, Uint32Array, Uint64Array
- Float32Array, Float64Array

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
On hold till [device-virtual-go PR#133](https://github.com/edgexfoundry/device-virtual-go/pull/133) is merged.