### PR TITLE
fix(microservices): fix all the links to common configuration

### DIFF
--- a/docs_src/general/ServiceConfiguration.md
+++ b/docs_src/general/ServiceConfiguration.md
@@ -6,7 +6,7 @@ See the [Configuration and Registry documentation](../microservices/configuratio
 
 Please refer to the EdgeX Foundry [architectural decision record](https://github.com/edgexfoundry/edgex-docs/blob/master/docs_src/design/adr/0005-Service-Self-Config.md) for details (and design decisions) behind the configuration in EdgeX.
 
-Please refer to the general [Configuration documentation](../microservices/configuration/Ch-Configuration.md#configuration) for configuration properties common to all services.  Find service specific configuration references in the tabs below.
+Please refer to the general [Configuration documentation](../microservices/configuration/Ch-Configuration.md#configuration-properties) for configuration properties common to all services.  Find service specific configuration references in the tabs below.
 
 === "Core"
     |Service Name|Configuration Reference|

--- a/docs_src/microservices/application/GeneralAppServiceConfig.md
+++ b/docs_src/microservices/application/GeneralAppServiceConfig.md
@@ -5,7 +5,7 @@ Similar to other EdgeX services, configuration is first determined by the `confi
 
 This section describes the configuration elements that are unique to Application Services
 
-Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration/#configuration) for configuration properties common across all services.
+Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration#configuration-properties) for configuration properties common across all services.
 
 !!! note
     `*`indicates the configuration value can be changed on the fly if using a configuration provider (like Consul).

--- a/docs_src/microservices/core/command/Ch-Command.md
+++ b/docs_src/microservices/core/command/Ch-Command.md
@@ -88,7 +88,7 @@ The two following High Level Diagrams show:
 
 ## Configuration Properties
 
-Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration) for configuration properties common to all services.
+Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration-properties) for configuration properties common to all services.
 
 === "Service"
     |Property|Default Value|Description|

--- a/docs_src/microservices/core/data/Ch-CoreData.md
+++ b/docs_src/microservices/core/data/Ch-CoreData.md
@@ -118,7 +118,7 @@ The two following High Level Interaction Diagrams show:
 
 ## Configuration Properties
 
-Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration) for configuration properties common to all services.
+Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration-properties) for configuration properties common to all services.
 
 === "Writable"
     |Property|Default Value|Description|

--- a/docs_src/microservices/core/metadata/Ch-Metadata.md
+++ b/docs_src/microservices/core/metadata/Ch-Metadata.md
@@ -401,7 +401,7 @@ Sequence diagrams for some of the more critical or complex events regarding meta
 
 ## Configuration Properties
 
-Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration) for configuration properties common to all services.
+Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration-properties) for configuration properties common to all services.
 
 === "Writable"
     |Property|Default Value|Description|

--- a/docs_src/microservices/device/Ch-DeviceServices.md
+++ b/docs_src/microservices/device/Ch-DeviceServices.md
@@ -113,7 +113,7 @@ The virtual device service ([device-virtual-go](https://github.com/edgexfoundry/
 
 ## Configuration Properties
 
-Please refer to the general [Configuration documentation](../configuration/Ch-Configuration.md#configuration) for configuration properties common to all services.
+Please refer to the general [Configuration documentation](../configuration/Ch-Configuration.md#configuration-properties) for configuration properties common to all services.
 
 === "Device"
     |Property|Default Value|Description|

--- a/docs_src/microservices/device/virtual/Ch-VirtualDevice.md
+++ b/docs_src/microservices/device/virtual/Ch-VirtualDevice.md
@@ -137,7 +137,7 @@ Use the following core command service APIs to execute commands against the virt
 
 ## Configuration Properties
 
-Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration) for configuration properties common to all services.
+Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration-properties) for configuration properties common to all services.
 
 For each device, the virual device service will contain a DeviceList with associated Protocols and AutoEvents as shown by the example below.
 === "DeviceList"   

--- a/docs_src/microservices/support/notifications/Ch-AlertsNotifications.md
+++ b/docs_src/microservices/support/notifications/Ch-AlertsNotifications.md
@@ -154,7 +154,7 @@ Cleanup service removes old notification and transmission records.
 
 ## Configuration Properties
 
-Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration) for configuration properties common to all services.
+Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration-properties) for configuration properties common to all services.
 
 === "Writable"
     |Property|Default Value|Description|

--- a/docs_src/microservices/support/scheduler/Ch-Scheduling.md
+++ b/docs_src/microservices/support/scheduler/Ch-Scheduling.md
@@ -80,7 +80,7 @@ The times and frequencies defined in the scheduler service's intervals are speci
 
 ## Configuration Properties
 
-Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration) for configuration properties common to all services.
+Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration-properties) for configuration properties common to all services.
 
 === "Writable"
     |Property|Default Value|Description|

--- a/docs_src/microservices/system-management/agent/Ch_SysMgmtAgent.md
+++ b/docs_src/microservices/system-management/agent/Ch_SysMgmtAgent.md
@@ -218,7 +218,7 @@ for the respective calls.  The tabs below provide the API path and corresponding
 
 ## Configuration Properties
 
-Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration) for configuration properties common to all services.
+Please refer to the general [Configuration documentation](../../configuration/Ch-Configuration.md#configuration-properties) for configuration properties common to all services.
 
 === "Writable"
     |Property|Default Value|Description|


### PR DESCRIPTION
fix links to point to common configuration properties and not just common configuration

fix #250

Signed-off-by: Jim White <jpwhite_mn@yahoo.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
none

Issue Number:
#250 

## What has been updated?
change links from Ch-Configuration.md#configuration to Ch-Configuration.md#configuration-properties where applicable 

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information