### PR TITLE
build: add Hanoi version 1.3

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: EdgeX Foundry Documentation
 docs_dir: ./docs_src
-site_dir: ./docs/1.2
+site_dir: ./docs/1.3
 site_description: 'Documentation for use of EdgeX Foundry'
 site_author: 'Michael Johanson'
 site_url: 'https://edgexfoundry.github.io/edgex-docs/'

--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,5 @@
 [
     {"version": "1.1", "title": "1.1-Fuji", "aliases": []},
-    {"version": "1.2", "title": "1.2-Geneva", "aliases": []}
+    {"version": "1.2", "title": "1.2-Geneva", "aliases": []},
+    {"version": "1.3", "title": "1.3-Hanoi", "aliases": []}
 ]


### PR DESCRIPTION
This will add a new version for Hanoi and will update mkdocs to generate site contents to a new folder.

Missing step not going to be done in this PR is to make 1.3 the default version when navigating to docs.edgexfoundry.org. That is done by updating this line: https://github.com/edgexfoundry/edgex-docs/blob/gh-pages/index.html#L6

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:

## What has been updated?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information