### PR TITLE
fix(legacy): clarify provision watcher matching for multiple protocols

### DIFF
--- a/docs_src/design/legacy-design/device-service/discovery.md
+++ b/docs_src/design/legacy-design/device-service/discovery.md
@@ -80,6 +80,8 @@ The filter criteria for discovered devices are represented by Provision Watchers
 
 A candidate new device passes a ProvisionWatcher if all of the `Identifiers` match, and none of the `BlockingIdentifiers`.
 
+For devices with multiple `Device.Protocols`, each `Device.Protocol` is considered separately. A pass (as described above) on any of the protocols results in the device being added.
+
 The values specified in `Identifiers` are regular expressions.
 
 **Note:** *the above is a whitelist+blacklist scheme. If a discovered Device is manually removed from EdgeX, it will be necessary to adjust the ProvisionWatcher via which it was added, either by making the `Identifiers` more specific or by adding `BlockingIdentifiers`, otherwise the Device will be re-added the next time Discovery is initiated.*


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
Provision Watcher operation for devices which may be addressed via multiple Protocol schemes was unclear. This was highlighted in https://github.com/edgexfoundry/device-sdk-go/issues/598


## Issue Number:


## What is the new behavior?
Added paragraph indicating that each Protocol is to be evaluated separately

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information