### PR TITLE
fix(ref): change default startup duration to 60 seconds

### DIFF
--- a/docs_src/microservices/application/AdvancedTopics.md
+++ b/docs_src/microservices/application/AdvancedTopics.md
@@ -248,7 +248,7 @@ This sets the `profile` so that the application service uses the `rules-engine` 
 
 #### EDGEX_STARTUP_DURATION
 
-This environment variable overrides the default duration, 30 seconds, for a service to complete the start-up, aka bootstrap, phase of execution
+This environment variable overrides the default duration, 60 seconds, for a service to complete the start-up, aka bootstrap, phase of execution
 
 #### EDGEX_STARTUP_INTERVAL
 

--- a/docs_src/microservices/configuration/Ch-Configuration.md
+++ b/docs_src/microservices/configuration/Ch-Configuration.md
@@ -170,7 +170,7 @@ The following tables document configuration properties that are common to all se
     |Property|Default Value|Description|
     |---|---|---|
     ||||config values that govern the StartupTimer created at boot for ensuring the service starts in a timely fashion|
-    |Duration| 30  | The maximum amount of time (in seconds) the service is given to complete the bootstrap phase.|
+    |Duration| 60 | The maximum amount of time (in seconds) the service is given to complete the bootstrap phase.|
     |Interval| 1  | The amount of time (in seconds) to sleep between retries on a failed dependency such as DB connection|
 === "SecretStore"
     |Property|Default Value|Description|


### PR DESCRIPTION
old value was 30 seconds

fixes: #267
Signed-off-by: Jim White <jpwhite_mn@yahoo.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
#267 

## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information