### PR TITLE
fix(ref): clean up all geneva specific references for hanoi

### DIFF
--- a/docs_src/design/adr/core/0003-V2-API-Principles.md
+++ b/docs_src/design/adr/core/0003-V2-API-Principles.md
@@ -4,6 +4,9 @@
 
 Accepted by EdgeX Foundry working groups as of Core Working Group meeting 16-Jan-2020
 
+!!! Note
+    This ADR was written pre-Geneva with an assumption that the V2 APIs would be available in Geneva.  In actuality, the full V2 APIs will be delivered in the Ireland release (Spring 2020)
+
 ## Context
 
 A redesign of the EdgeX Foundry API is proposed for the Geneva release. This is understood by the community to warrant a 2.0 release that will not be backward compatible. The goal is to rework the API using solid principles that will allow for extension over the course of several release cycles, avoiding the necessity of yet another major release version in a short period of time.

--- a/docs_src/examples/Ch-ExamplesAddingMQTTDevice.md
+++ b/docs_src/examples/Ch-ExamplesAddingMQTTDevice.md
@@ -327,6 +327,9 @@ replacing the host IP with your host address:
 Download the `Geneva` release docker-compose file from
 <https://github.com/edgexfoundry/developer-scripts/blob/master/releases/geneva/compose-files/docker-compose-geneva-redis.yml>.
 
+!!! Note
+    This example uses the Geneva Release.  There are later EdgeX releases.
+
 Because we deploy EdgeX using docker-compose, we must add device-mqtt to
 the docker-compose file. If you have prepared configuration files, you
 can mount them using volumes and change the entrypoint for device-mqtt

--- a/docs_src/examples/Ch-ExamplesAddingModbusDevice.md
+++ b/docs_src/examples/Ch-ExamplesAddingModbusDevice.md
@@ -346,6 +346,9 @@ volumes and change the entrypoint for device-modbus internal use.
 
 ![configuration.toml Updates](config_changes.png)
 
+!!! Note
+    This example uses the Geneva Release.  There are later EdgeX releases.
+
 ## Start EdgeX Foundry on Docker
 
 Finally, we can deploy EdgeX in the Photon OS.

--- a/docs_src/getting-started/Ch-GettingStartedSDK-C.md
+++ b/docs_src/getting-started/Ch-GettingStartedSDK-C.md
@@ -20,7 +20,7 @@ The next step is to download and build the EdgeX device service SDK for C.
     ![image](EdgeX_GettingStartedSDKCloneC.png)
 
     !!! Note
-        The clone command above has you pull v1.2.1 of the C SDK which is the version compatible with the Geneva release.
+        The clone command above has you pull v1.2.1 of the C SDK which is the version compatible with the Geneva release.  There are later releases of EdgeX.  While backward compatible, it is always a good idea to pull and use the latest version associated with the major version of EdgeX you are using.
 
 2.  Then, build the device-sdk-c:
     ``` bash

--- a/docs_src/getting-started/Ch-GettingStartedSDK-Go.md
+++ b/docs_src/getting-started/Ch-GettingStartedSDK-Go.md
@@ -26,7 +26,7 @@ download the [Device SDK](../../microservices/device/sdk/Ch-DeviceSDK), and get 
     ![image](EdgeX_GettingStartedSDKClone.png)
 
     !!! Note
-        The clone command above has you pull v1.2.2 of the Go SDK which is the version associated to Geneva.  You may want to check for the latest released version by going to https://github.com/edgexfoundry/device-sdk-go and look for the lastest release tag.
+        The clone command above has you pull v1.2.2 of the Go SDK which is the version associated to Geneva.  There are later releases of EdgeX.  While backward compatible, it is always a good idea to pull and use the latest version associated with the major version of EdgeX you are using.  You may want to check for the latest released version by going to https://github.com/edgexfoundry/device-sdk-go and look for the latest release.
 
 3.  Create a folder that will hold the new device service.  The name of the folder is also the name you want to give your new device service. Standard practice in EdgeX is to prefix the name of a device service with `device-`.  In this example, the name 'device-simple` is used.
     ``` bash

--- a/docs_src/getting-started/Ch-GettingStartedUsers.md
+++ b/docs_src/getting-started/Ch-GettingStartedUsers.md
@@ -44,39 +44,31 @@ The EdgeX development team provides Docker Compose files for each release.  Visi
 !!! Note
     At the GitHub location specified above there is a folder for each EdgeX release.  The nightly-build folder contains Docker Compose files that use artifacts created from the latest code submitted by contributors.  Most end users should avoid using these Docker Compose files.  They are work-in-progress.  Users should use the Docker Compose files for the latest version of EdgeX. 
 
-In each folder, you will find several Docker Compose files (all with a .yml extension).  The name of the file will suggest the type of EdgeX instance the Compose file will help setup.  The table below provides a list of the Docker Compose filenames for the latest release (Geneva).   Find the Docker Compose file that matches:
+In each folder, you will find several Docker Compose files (all with a .yml extension).  The name of the file will suggest the type of EdgeX instance the Compose file will help setup.  The table below provides a list of the Docker Compose filenames for the latest release (Hanoi).   Find the Docker Compose file that matches:
 
 - your hardware (x86 or ARM)
-- the database you want to use (Mongo or Redis)
 - your desire to have security services on or off
 
 |filename|Docker Compose contents|
 |---|---|
-|docker-compose-geneva-mongo-arm64.yml |Specifies ARM 64 containers, uses Mongo database for persistence, and includes security services|
-|docker-compose-geneva-mongo-no-secty-arm64.yml|Specifies x86 containers, uses Mongo database for persistence, but does not include security services|
-|docker-compose-geneva-mongo-no-secty.yml| Specifies x86 containers, uses Mongo database for persistence, but does not include security services|
-|docker-compose-geneva-mongo.yml|Specifies x86 containers, uses Mongo database for persistence, and includes security services|
-|docker-compose-geneva-redis-arm64.yml|Specifies x86 containers, uses Redis database for persistence, and includes security services|
-|docker-compose-geneva-redis-no-secty-arm64.yml|Specifies ARM 64 containers, uses Redis database for persistence, but does not include security services|
-|docker-compose-geneva-redis-no-secty.yml|Specifies x86 containers, uses Redis database for persistence, but does not include security services|
-|docker-compose-geneva-redis.yml|Specifies x86 containers, uses Redis database for persistence, and includes security services|
-|docker-compose-geneva-ui-arm64.|Specifies the EdgeX user interface extension to be used with the ARM 64 EdgeX platform|
-|docker-compose-geneva-ui.yml|Specifies the EdgeX user interface extension to be used with the x86 EdgeX platform|
+|docker-compose-hanoi-arm64.yml|Specifies x86 containers, uses Redis database for persistence, and includes security services|
+|docker-compose-hanoi-no-secty-arm64.yml|Specifies ARM 64 containers, uses Redis database for persistence, but does not include security services|
+|docker-compose-hanoi-no-secty.yml|Specifies x86 containers, uses Redis database for persistence, but does not include security services|
+|docker-compose-hanoi.yml|Specifies x86 containers, uses Redis database for persistence, and includes security services|
+|docker-compose-hanoi-ui-arm64.|Specifies the EdgeX user interface extension to be used with the ARM 64 EdgeX platform|
+|docker-compose-hanoi-ui.yml|Specifies the EdgeX user interface extension to be used with the x86 EdgeX platform|
 |docker-compose-portainer.yml|Specifies the Portainer user interface extension (to be used with the x86 or ARM EdgeX platform)|
 
-!!! Info
-    Unsure which Docker Compose file to use?  The EdgeX community recommends you use the Reds, no security Docker Compose file for your architecture to start.  As you learn about EdgeX, you can incorporate security elements.  The Mongo database is being archived with the next release. 
-
 ### Download a EdgeX Foundry Compose File
-Once you have selected the EdgeX Compose file you want to use, download it using your favorite tool.  The examples below uses *wget* to fetch Docker Compose for the Geneva release, no security, Redis database.
+Once you have selected the EdgeX Compose file you want to use, download it using your favorite tool.  The examples below uses *wget* to fetch Docker Compose for the Hanoi release with no security.
 
 === "x86"
     ```
-    wget https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty.yml -O docker-compose.yml
+    wget https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/hanoi/compose-files/docker-compose-hanoi-no-secty.yml -O docker-compose.yml
     ```
 === "ARM"
     ```
-    wget https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty-arm64.yml -O docker-compose.yml
+    wget https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/hanoi/compose-files/docker-compose-hanoi-no-secty-arm64.yml -O docker-compose.yml
     ```
 
 !!! Note

--- a/docs_src/index.md
+++ b/docs_src/index.md
@@ -235,9 +235,11 @@ The code name of each release is named after some geographical location in the w
 |Edinburgh |Jul 2019 | 1.0.0 |
 |Fuji |Nov 2019 | 1.1.0 |
 |Geneva |May 2020 | 1.2.0 |
-|Hanoi |Fall 2020 | TBD |
+|Hanoi |November 2020 | 1.3.0 |
 |Ireland |Spring 2021 | TBD |
 |Jakarta |Fall 2021 | TBD |
+|Kamukura |Spring 2022| TBD |
+|Levski| Fall 2022| TBD|
 
 *Note*: minor releases of the Device Services and Application Services (along with their associated SDKs) can be release independently.
 

--- a/docs_src/microservices/core/database/Ch-Redis.md
+++ b/docs_src/microservices/core/database/Ch-Redis.md
@@ -1,0 +1,20 @@
+# Redis Database
+
+EdgeX Foundry's reference implementation database (for sensor data, metadata and all things that need to be persisted in a database) is Redis.
+
+Redis is an open source (BSD licensed), in-memory data structure store, used as a database and message broker in EdgeX. It supports data structures such as strings, hashes, lists, sets, sorted sets with range queries, bitmaps, hyperloglogs, geospatial indexes with radius queries and streams. Redis is durable and uses persistence only for recovering state; the only data Redis operates on is in-memory.
+
+## Memory Utilization
+
+Redis uses a number of techniques to optimize memory utilization. Antirez and [Redis Labs](https://redislabs.com/) have written a number of articles on the underlying details (see the list below) and those strategies has continued to [evolve](http://antirez.com/news/128). When thinking about your system architecture, consider how long data will be living at the edge and consuming memory (physical or physical + virtual).
+
+- [http://antirez.com/news/92](http://antirez.com/news/92)
+- [https://redislabs.com/blog/redis-ram-ramifications-part-i/](https://redislabs.com/blog/redis-ram-ramifications-part-i/)
+- [https://redis.io/topics/memory-optimization](https://redis.io/topics/memory-optimization)
+- [http://antirez.com/news/128](http://antirez.com/news/128)
+
+## On-disk Persistence
+
+Redis supports a number of different levels of on-disk persistence. By default, snapshots of the data are persisted every 60 seconds or after 1000 keys have changed. Beyond increasing the frequency of snapshots, append only files that log every database write are also supported. See https://redis.io/topics/persistence for a detailed discussion on how to balance the options.
+
+Redis supports setting a memory usage limit and a policy on what to do if memory cannot be allocated for a write. See the MEMORY MANAGEMENT section of https://raw.githubusercontent.com/antirez/redis/5.0/redis.conf for the configuration options. Since EdgeX and Redis do not currently communicate on data evictions, you will need to use the EdgeX scheduler to control memory usage rather than a Redis eviction policy.

--- a/docs_src/microservices/security/Ch-Docker-Swarm-SecuringDeviceServices.md
+++ b/docs_src/microservices/security/Ch-Docker-Swarm-SecuringDeviceServices.md
@@ -192,7 +192,7 @@ restart_policy:
   condition: on-failure
 ```
 
-The next and final change in the stack yml file is to ensure the EdgeX services are binding to the correct host.  In Geneva we do this by adding a common variable `Service_ServerBindAddr: "0.0.0.0"` to ensure that the service will bind to any host and not be limited to the hostname.  
+The next and final change in the stack yml file is to ensure the EdgeX services are binding to the correct host.  Since Geneva we do this by adding a common variable `Service_ServerBindAddr: "0.0.0.0"` to ensure that the service will bind to any host and not be limited to the hostname.  
 
 ### Running the docker stack file
 

--- a/docs_src/microservices/security/Ch-SecretStore.md
+++ b/docs_src/microservices/security/Ch-SecretStore.md
@@ -67,6 +67,9 @@ file. The whole set of Docker Compose files for Geneva release can be found here
 
 > -   <https://github.com/edgexfoundry/developer-scripts/blob/master/releases/geneva/compose-files>
 
+!!! Note
+    This example uses the Geneva Release.  There are later EdgeX releases.
+
 [The Compose file](https://github.com/edgexfoundry/developer-scripts/blob/master/releases/geneva/compose-files/docker-compose-geneva-redis.yml) starts the entire EdgeX Foundry platform with Redis including the security services.
 
 The command to start EdgeX Foundry platform including the Secret Store

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
         - './microservices/core/data/Ch-CoreData.md'
         - './microservices/core/metadata/Ch-Metadata.md'
         - './microservices/core/command/Ch-Command.md'
+        - './microservices/core/database/Ch-Redis.md'
       - Supporting Services:
         - './microservices/support/Ch-SupportingServices.md'
         - './microservices/support/logging/Ch-Logging.md'


### PR DESCRIPTION
fixes:#293

changed references to Geneva compose files where it was easy to do
changed any place where Geneva was referenced as the latest release
made note where Geneva is used in examples that later releases do exist
added Redis guidance to core services (from the Wiki)
updated release cadence and future release names

Signed-off-by: Jim White <jpwhite_mn@yahoo.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
n/a

## Issue Number:
#293 

## What is the new behavior?
clean up of Geneva references to provide better clarity in the docs

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information