### PR TITLE
fix(legacy): Remove noninclusive language from device discovery spec

### DIFF
--- a/docs_src/design/legacy-design/device-service/discovery.md
+++ b/docs_src/design/legacy-design/device-service/discovery.md
@@ -84,6 +84,6 @@ For devices with multiple `Device.Protocols`, each `Device.Protocol` is consider
 
 The values specified in `Identifiers` are regular expressions.
 
-**Note:** *the above is a whitelist+blacklist scheme. If a discovered Device is manually removed from EdgeX, it will be necessary to adjust the ProvisionWatcher via which it was added, either by making the `Identifiers` more specific or by adding `BlockingIdentifiers`, otherwise the Device will be re-added the next time Discovery is initiated.*
+**Note:** *If a discovered Device is manually removed from EdgeX, it will be necessary to adjust the ProvisionWatcher via which it was added, either by making the `Identifiers` more specific or by adding `BlockingIdentifiers`, otherwise the Device will be re-added the next time Discovery is initiated.*
 
 **Note:** *ProvisionWatchers are stored in core-metadata. A facility for managing ProvisionWatchers is needed, eg `edgex-cli` could be extended*


### PR DESCRIPTION
Signed-off-by: Iain Anderson <iain@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Use of noninclusive terminology

## Issue Number:


## What is the new behavior?
Removed blacklist/whitelist reference

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information