### PR TITLE
fix(adr): Update device service V2 API documentation for the value range of operating state

### DIFF
--- a/docs_src/design/adr/device-service/0011-DeviceService-Rest-API.md
+++ b/docs_src/design/adr/device-service/0011-DeviceService-Rest-API.md
@@ -133,7 +133,7 @@ Calls to the device endpoints may include a Query String in the URL. This may be
 
 #### Device States
 
-A Device in EdgeX has two states associated with it: the Administrative state and the Operational state. The Administrative state may be set to `LOCKED` (normally `UNLOCKED`) to block access to the device for administrative reasons. The Operational state may be set to `DISABLED` (normally `ENABLED`) to indicate that the device is not currently working. In either case access to the device via this endpoint will be denied and HTTP 423 ("Locked") will be returned.
+A Device in EdgeX has two states associated with it: the Administrative state and the Operational state. The Administrative state may be set to `LOCKED` (normally `UNLOCKED`) to block access to the device for administrative reasons. The Operational state may be set to `DOWN` (normally `UP`) to indicate that the device is not currently working. In either case access to the device via this endpoint will be denied and HTTP 423 ("Locked") will be returned.
 
 #### Data Transformations
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #331 

## What is the new behavior?
The V2 of operating state has been decided to use value range UP/DOWN/UNKNOWN; however, https://github.com/edgexfoundry/edgex-docs/blob/master/docs_src/design/adr/device-service/0011-DeviceService-Rest-API.md#device-states is still using value range ENABLED/DISABLED, which needs to be updated.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No