### PR TITLE
fix: Adjust the Hanoi custom compose build directions

### DIFF
--- a/docs_src/getting-started/Ch-GettingStartedUsers.md
+++ b/docs_src/getting-started/Ch-GettingStartedUsers.md
@@ -86,10 +86,10 @@ Do the following to use this tool:
    git clone https://github.com/edgexfoundry/developer-scripts.git
    ```
 
-2. Checkout the Hanoi tag
+2. Checkout the Hanoi branch
 
    ```
-   git checkout v1.3.0
+   git checkout hanoi
    ```
 
 3. Use the `make gen <options>` command to generate your custom compose file. The generated docker compose file is named `docker-compose.yaml`.  Here are some examples:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
Directions reference 1.3.0 tag

## Issue Number: #333


## What is the new behavior?
Directions now reference the `hanoi` branch


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information