### PR TITLE
fix(adr): updated 0002 to remove proposed V2 API changes

### DIFF
--- a/docs_src/design/adr/device-service/0002-Array-Datatypes.md
+++ b/docs_src/design/adr/device-service/0002-Array-Datatypes.md
@@ -28,13 +28,7 @@ The permitted values of the `Type` field in `PropertyValue` are extended to incl
 
 ### Readings
 
-#### Implementation in v2 API
-
-The `value` field of `SimpleReading` becomes an array of strings. For non-array types, an array of length 1 is created.
-
-#### Fallback position for v1 API
-
-In the v1 API, `Reading.Value` is a string representation of the data. If this is maintained, the representation for Array types will follow the JSON array syntax, ie `["value1", "value2", ...]`
+In the API (v1 and v2), `Reading.Value` is a string representation of the data. If this is maintained, the representation for Array types will follow the JSON array syntax, ie `["value1", "value2", ...]`
 
 ## Consequences
 


### PR DESCRIPTION
Removed the implementation for v2 API changes on array of strings and non-array types that was overruled by architect's meeting in January.

Decision was made to keep implementation as it is in v1

Signed-off-by: Jim White <jpwhite_mn@yahoo.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
Takes out suggestion that there will be a change in Readings for arrays for V2.  This was reversed in the Jan 2021 Architect's meeting