### PR TITLE
fix: Hanoi - Change Compose Builder mqtt option to mqtt-bus

### DIFF
--- a/docs_src/getting-started/Ch-GettingStartedUsers.md
+++ b/docs_src/getting-started/Ch-GettingStartedUsers.md
@@ -95,7 +95,7 @@ Do the following to use this tool:
 3. Use the `make gen <options>` command to generate your custom compose file. The generated docker compose file is named `docker-compose.yaml`.  Here are some examples:
 
    ```
-   make gen ds-mqtt mqtt 
+   make gen ds-mqtt mqtt-bus 
      - Generates secure compose file configured to use MQTT for the message bus, adds then MQTT broker and the Device MQTT services. 
    
    make gen no-secty ds-modbus 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
Custom compose section has example using `mqtt` option

## Issue Number:  #338


## What is the new behavior?
Custom compose section example now uses `mqtt-bus` option

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information