### PR TITLE
fix: Hanoi: Update link to Compose Builder README to be from the `hanoi` branch

### DIFF
--- a/docs_src/getting-started/Ch-GettingStartedUsers.md
+++ b/docs_src/getting-started/Ch-GettingStartedUsers.md
@@ -105,7 +105,7 @@ Do the following to use this tool:
      - Generates non-secure compose file for ARM64 with just the Device Grove device service.
    ```
 
-​      See the [README](https://github.com/edgexfoundry/developer-scripts/blob/v1.3.0/compose-builder/README.md) here for details on all available options for `make gen`.
+​      See the [README](https://github.com/edgexfoundry/developer-scripts/blob/hanoi/compose-builder/README.md) here for details on all available options for `make gen`.
 
 !!! Note
     The generated docker compose file may need addition customizations for your specific needs, such as environment override(s) to set appropriate Host IP address, etc.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
README link is to the `1.3.0 tag` 

## Issue Number: #346


## What is the new behavior?
README link is to the `hanoi branch` 


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information