### PR TITLE
fix(microservices): fix description of frequency for scheduler interval

### DIFF
--- a/docs_src/api/supporting/Ch-APISupportingServicesScheduling.md
+++ b/docs_src/api/supporting/Ch-APISupportingServicesScheduling.md
@@ -24,8 +24,7 @@ action(s).
         ISO 8601 YYYYMMDD't'HHmmss format. Empty means now.
     -   **end** - identifies when the operation ends. Expressed in ISO
         8601 YYYYMMDD't'HHmmss format. Empty means never
-    -   **frequency** - identifies the interval between invocations.
-        Expressed in ISO 8601 PxYxMxDTxHxMxS format. Empty means no
+    -   **frequency** - How often the specific resource needs to be polled. It represents as a duration string. The format of this field is to be an unsigned integer followed by a unit which may be "ns", "us" (or "µs"), "ms", "s", "m", "h" representing nanoseconds, microseconds, milliseconds, seconds, minutes or hours. Eg, "100ms", "24h" Empty means no
         frequency.
 
 **Interval Action(s)**
@@ -51,7 +50,7 @@ Create an interval upon which the scheduler will operate :
 curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
 
 :   "name": "midnight", "start": "20180101T000000",
-    "frequency": "P1D"}'
+    "frequency": "24h"}'
     "<http://localhost:48081/api/v1/interval>"
 
 Example of a second interval which will run every 20 seconds :
@@ -59,7 +58,7 @@ Example of a second interval which will run every 20 seconds :
 curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
 
 :   "name": "every20s", "start":"20000101T000000", "end":"",
-    "frequency":"PT20S"}'
+    "frequency":"20s"}'
     "<http://localhost:48081/api/v1/interval>"
 
 Create an interval action that will invoke the interval action (drive

--- a/docs_src/microservices/support/scheduler/Ch-Scheduling.md
+++ b/docs_src/microservices/support/scheduler/Ch-Scheduling.md
@@ -46,7 +46,7 @@ The times and frequencies defined in the scheduler service's intervals are speci
     |Name |the name of the given interval|
     |start|The start time of the given interval in ISO 8601 format|
     |end|The end time of the given interval in ISO 8601 format|
-    |frequency |Periodicity of the interval according to ISO 8601|
+    |frequency |How often the specific resource needs to be polled. It represents as a duration string. The format of this field is to be an unsigned integer followed by a unit which may be "ns", "us" (or "µs"), "ms", "s", "m", "h" representing nanoseconds, microseconds, milliseconds, seconds, minutes or hours. Eg, "100ms", "24h"|
     |cron|cron styled regular expression indicating how often the action under interval should occur.  Use either runOnce, frequency or cron and not all|
     |runOnce|boolean indicating that this interval runs one time - at the time indicated by the start|
 === "IntervalAction"


### PR DESCRIPTION
frequency does not abide by the ISO 8601 standard

Signed-off-by: Jim White <jpwhite_mn@yahoo.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
error in docs suggesting interval frequency abides by ISO standard

## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information