### PR TITLE
fix: Correct list of SDKs in Introduction

### DIFF
--- a/docs_src/index.md
+++ b/docs_src/index.md
@@ -168,7 +168,7 @@ SDKs are language specific; meaning an SDK is written to create services in a pa
 
 - Golang Device Service SDK
 - C Device Service SDK
-- Golang Device Service SDK
+- Golang Application Functions SDK
 
 ## How EdgeX Works
 


### PR DESCRIPTION

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [x ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
The list of SDKs contains twice the Golang Device SDK.

## Issue Number:


## What is the new behavior?
The list only contains the Golang Device SDK once and lists the Golang Application SDK.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
None

## Other information