### PR TITLE
feat: add docs as one type of conventional commits

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -2,6 +2,7 @@ allowMergeCommits: true
 # Always validate the PR title AND all the commits
 titleAndCommits: true
 types:
+    - docs
     - feat
     - fix
     - style


### PR DESCRIPTION
docs should be supported as part of specs from conventional commit org.

Fixes: #406
Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
no support docs: as type of git commits

## Issue Number: #406 


## What is the new behavior?
added support for docs:

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information