### PR TITLE
build: Change the default docs landing page to be 2.0

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Redirecting</title>
   <script>
-    window.location.replace("1.3");
+    window.location.replace("2.0");
   </script>
 </head>
 <body>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
Default to 1.3 docs

## Issue Number: n/a


## What is the new behavior?
Now defaults to 2.0 docs

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information