### PR TITLE
feat: Add dependencies section to App Service migration guide

### DIFF
--- a/docs_src/microservices/application/V2Migration.md
+++ b/docs_src/microservices/application/V2Migration.md
@@ -39,10 +39,6 @@ The client used for the version validation check has changed to being from Core 
         Host = "localhost"
         Port = 59881
         
-    ```
-
-    ```
-    
         # Used for Event client which is used by PushToCoreData function
         [Clients.core-data]
         Protocol = "http"
@@ -140,7 +136,39 @@ The HTTP trigger configuration has not changed beyond the renaming of `Binding` 
 
 ### Code
 
-The first changes you will encounter in your code are that the `AppFunctionsSDK` and `Context` structs have been abstracted into the new `ApplicationService` and `AppFunctionContext` APIs. See the [Application Service API](../ApplicationServiceAPI) and [App Function Context API](../AppFunctionContextAPI) sections for complete details on these new APIs.
+#### Dependencies
+
+You first need to update the `go.mod` file to specify `go 1.16` and the V2 versions of the App Functions SDK and any EdgeX go-mods directly used by your service. Note the extra `/v2` for the modules.
+
+!!! example "Example go.mod for V2"
+
+    ```go
+    module <your service>
+    
+    go 1.16
+    
+    require (
+    	github.com/edgexfoundry/app-functions-sdk-go/v2 v2.0.0
+    	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0
+    )
+    ```
+
+Once that is complete then the import statements for these dependencies must be updated to include the `/v2` in the path. 
+
+!!! example "Example import statements for V2"
+
+    ```go
+    import (
+    	...
+        
+    	"github.com/edgexfoundry/app-functions-sdk-go/v2/pkg/interfaces"
+    	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+    )
+    ```
+
+#### New APIs
+
+Next changes you will encounter in your code are that the `AppFunctionsSDK` and `Context` structs have been abstracted into the new `ApplicationService` and `AppFunctionContext` APIs. See the [Application Service API](../ApplicationServiceAPI) and [App Function Context API](../AppFunctionContextAPI) sections for complete details on these new APIs. The following sections cover migrating your code for these new APIs.
 
 #### main()
 
@@ -278,7 +306,7 @@ The `PushToCore` API replaces the `PushToCoreData` function. The API signature h
 
 ##### New Capabilities
 
-Some new capabilities have been added to the new AppFunctionContext API. See the [App Function Context](../AppFunctionContextAPI) API section for complete details.
+Some new capabilities have been added to the new `AppFunctionContext` API. See the [App Function Context](../AppFunctionContextAPI) API section for complete details.
 
 ## App Service Configurable Profiles
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
No section in App Services Migration Guide for dealing with V2 dependencies

## Issue Number: #506


## What is the new behavior?
New section added to App Services Migration Guide for dealing with V2 dependencies

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information