### PR TITLE
fix: Clean up TOML examples to have only double quotes

### DIFF
--- a/docs_src/design/adr/013-Device-Service-Events-Message-Bus.md
+++ b/docs_src/design/adr/013-Device-Service-Events-Message-Bus.md
@@ -112,7 +112,7 @@ This new topic approach will be enabled via each publisher's `PublishTopic` havi
 
 ```toml
 
-PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
+PublishTopicPrefix = "edgex/events" # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
 ```
 
 See [Configuration](#configuration) section below for details. 
@@ -130,11 +130,11 @@ A  MessageQueue section will be added, which is similar to that used in Core Dat
 ```toml
 [MessageQueue]
 Enabled = true
-Protocol = 'tcp'
-Host = 'localhost'
+Protocol = "tcp"
+Host = "localhost"
 Port = 1883
-Type = 'mqtt'
-PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
+Type = "mqtt"
+PublishTopicPrefix = "edgex/events" # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
 [MessageQueue.Optional]
     # Default MQTT Specific options that need to be here to enable environment variable overrides of them
     # Client Identifiers
@@ -160,13 +160,13 @@ The `MessageQueue` section will be  changed so that the `Topic` property changes
 
 ```toml
 [MessageQueue]
-Protocol = 'tcp'
-Host = 'localhost'
+Protocol = "tcp"
+Host = "localhost"
 Port = 1883
-Type = 'mqtt'
-PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
+Type = "mqtt"
+PublishTopicPrefix = "edgex/events" # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
 SubscribeEnabled = true
-SubscribeTopic = 'edgex/events/#'
+SubscribeTopic = "edgex/events/#"
 [MessageQueue.Optional]
     # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
     # Client Identifiers

--- a/docs_src/design/adr/014-Secret-Provider-For-All.md
+++ b/docs_src/design/adr/014-Secret-Provider-For-All.md
@@ -231,13 +231,13 @@ Core Data
 ```toml
 [Databases]
   [Databases.Primary]
-  Host = 'localhost'
-  Name = 'coredata'
-  Username = ''
-  Password = ''
+  Host = "localhost"
+  Name = "coredata"
+  Username = ""
+  Password = ""
   Port = 6379
   Timeout = 5000
-  Type = 'redisdb'
+  Type = "redisdb"
 ```
 
 Application Services
@@ -247,8 +247,8 @@ Application Services
 Type = "redisdb"
 Host = "localhost"
 Port = 6379
-Username = ''
-Password = ''
+Username = ""
+Password = ""
 Timeout = "30s"
 ```
 

--- a/docs_src/examples/Ch-ExamplesAddingMQTTDevice.md
+++ b/docs_src/examples/Ch-ExamplesAddingMQTTDevice.md
@@ -54,7 +54,7 @@ This simulator has three behaviors:
 
 To simulate the MQTT device, create a javascript, named `mock-device.js`, with the
 following content:
-```
+```javascript
 function getRandomFloat(min, max) {
     return Math.random() * (max - min) + min;
 }
@@ -127,7 +127,7 @@ which can be Read or Write.
 
 Create a device profile, named `mqtt.test.device.profile.yml`, with the
 following content:
-```
+```yaml
 name: "MQTT-Test-Device-Profile"
 manufacturer: "iot"
 model: "MQTT-DEVICE"
@@ -176,20 +176,20 @@ device-mqtt generates a relative instance on start-up.
 
 Create the device configuration file, named `mqtt.test.device.config.toml`, as shown below:
 
-```
+```toml
 # Pre-define Devices
 [[DeviceList]]
-  Name = 'MQTT-Test-Device'
-  ProfileName = 'MQTT-Test-Device-Profile'
-  Description = 'MQTT device is created for test purpose'
-  Labels = [ 'MQTT', 'test' ]
+  Name = "MQTT-Test-Device"
+  ProfileName = "MQTT-Test-Device-Profile"
+  Description = "MQTT device is created for test purpose"
+  Labels = [ "MQTT", "test" ]
   [DeviceList.Protocols]
     [DeviceList.Protocols.mqtt]
-       CommandTopic = 'CommandTopic'
+       CommandTopic = "CommandTopic"
     [[DeviceList.AutoEvents]]
-       Interval = '30s'
+       Interval = "30s"
        OnChange = false
-       SourceName = 'message'
+       SourceName = "message"
 ```
 
 - `CommandTopic` is used to publish the GET or SET command request
@@ -218,7 +218,7 @@ Open the `docker-compose.yml` file and then add volumes path and environment as 
 
 - Replace the `/path/to/custom-config` in the example with the correct path
 
-```
+```yaml
  device-mqtt:
     ...
     environment:
@@ -250,7 +250,7 @@ Now we're ready to run some commands.
 
 Use the following query to find executable commands:
 
-```
+```json
 $ curl http://localhost:59882/api/v2/device/all | json_pp
 
 {
@@ -315,7 +315,7 @@ $ curl http://localhost:59882/api/v2/device/name/MQTT-Test-Device/message \
 
 Execute a GET command as follows:
 
-```
+```json
 $ curl http://localhost:59882/api/v2/device/name/MQTT-Test-Device/message | json_pp
 
 {
@@ -350,18 +350,18 @@ $ curl http://localhost:59882/api/v2/device/name/MQTT-Test-Device/message | json
 
 The schedule job is defined in the `[[DeviceList.AutoEvents]]` section of the device configuration file:
 
-```
+```toml
     [[DeviceList.AutoEvents]]
-       Interval = '30s'
+       Interval = "30s"
        OnChange = false
-       SourceName = 'message'
+       SourceName = "message"
 ```
 
 After the service starts, query core-data's reading API. The results
 show that the service auto-executes the command every 30 secs, as shown
 below:
 
-```
+```json
 $ curl http://localhost:59880/api/v2/reading/resourceName/message | json_pp
 
 {
@@ -412,7 +412,7 @@ The data format contains the following values:
 The following results show that the mock device sent the reading every
 15 secs:
 
-```
+```json
 $ curl http://localhost:59880/api/v2/reading/resourceName/randnum | json_pp
 
 {
@@ -470,7 +470,7 @@ MQTT Device Service has the following configurations to implement the MQTT proto
 
 The user can override these configurations by `environment variable` to meet their requirement, for example:
 
-```
+```yaml
 # docker-compose.yml
 
  device-mqtt:

--- a/docs_src/examples/Ch-ExamplesAddingModbusDevice.md
+++ b/docs_src/examples/Ch-ExamplesAddingModbusDevice.md
@@ -83,7 +83,7 @@ nano temperature.profile.yml
 ```
 
 Fill in the device profile according to the [Modbus Register Table](#modbus-register-table), as shown below:
-```
+```yaml
 name: "Ethernet-Temperature-Sensor"
 manufacturer: "Audon Electronics"
 model: "Temperature"
@@ -168,7 +168,7 @@ For example: `{ primaryTable: "INPUT_REGISTERS", startingAddress: "4", isByteSwa
 
 We only support `Int16` and `Uint16` for rawType. The corresponding value type must be `Float32` and `Float64`.
 For example:
-```
+```yaml
 deviceResources:
   -
     name: "Temperature"
@@ -199,23 +199,23 @@ cd custom-config
 nano device.config.toml
 ```
 Fill in the device.config.toml file, as shown below:
-```
+```toml
 [[DeviceList]]
-    Name = 'Modbus-TCP-Temperature-Sensor'
-    ProfileName = 'Ethernet-Temperature-Sensor'
-    Description = 'This device is a product for monitoring the temperature via the ethernet'
-    labels = [ 'temperature','modbus TCP' ]
+    Name = "Modbus-TCP-Temperature-Sensor"
+    ProfileName = "Ethernet-Temperature-Sensor"
+    Description = "This device is a product for monitoring the temperature via the ethernet"
+    labels = [ "temperature","modbus TCP" ]
     [DeviceList.Protocols]
         [DeviceList.Protocols.modbus-tcp]
-            Address = '172.17.0.1'
-            Port = '502'
-            UnitID = '1'
+            Address = "172.17.0.1"
+            Port = "502"
+            UnitID = "1"
             Timeout = "5"
             IdleTimeout = "5"
         [[DeviceList.AutoEvents]]
-        Interval = '30s'
+        Interval = "30s"
         OnChange = false
-        SourceName = 'Temperature'
+        SourceName = "Temperature"
 ```
 > The address `172.17.0.1` is point to the docker bridge network which means it can forward the request from docker network to the host.
 
@@ -256,7 +256,7 @@ Add prepared configuration files to docker-compose file, you can mount them usin
 volumes and change the environment for device-modbus internal use.
 
 Open the `docker-compose.yml` file and then add volumes path and environment as shown below:
-```
+```yaml
  device-modbus:
     ...
     environment:
@@ -359,7 +359,7 @@ Now we're ready to run some commands.
 ### Find Executable Commands
 
 Use the following query to find executable commands:
-```
+```json
 $ curl http://localhost:59882/api/v2/device/all | json_pp
 
 {
@@ -433,7 +433,7 @@ $ curl http://localhost:59882/api/v2/device/name/Modbus-TCP-Temperature-Sensor/A
 
 Replace *\<host\>* with the server IP when running the GET command.
 
-```
+```json
 $ curl http://localhost:59882/api/v2/device/name/Modbus-TCP-Temperature-Sensor/AlarmThreshold | json_pp
 
 {
@@ -477,16 +477,16 @@ $ curl http://localhost:59882/api/v2/device/name/Modbus-TCP-Temperature-Sensor/A
 
 ## AutoEvent
 The AutoEvent is defined in the [[DeviceList.AutoEvents]] section of the device configuration file:
-```
+```toml
 [[DeviceList.AutoEvents]]
-Interval = '30s'
+Interval = "30s"
 OnChange = false
-SourceName = 'Temperature'
+SourceName = "Temperature"
 ```
 After service startup, query core-data's API. The results show
 that the service auto-executes the command every 30 seconds.
 
-```
+```json
 $ curl http://localhost:59880/api/v2/event/device/name/Modbus-TCP-Temperature-Sensor | json_pp
 
 {
@@ -590,7 +590,7 @@ This section describes how to connect the Modbus RTU device. We use Ubuntu OS an
     ```
     $ nano modbus.rtu.demo.profile.yml
     ```
-    ```
+    ```yaml
     name: "Modbus-RTU-IO-Module"
     manufacturer: "icpdas"
     model: "M-7055"
@@ -646,7 +646,7 @@ This section describes how to connect the Modbus RTU device. We use Ubuntu OS an
 
 3. Create the device entity to the EdgeX.
     You can find the Modbus RTU setting on the device or the user manual.
-    ```
+    ```json
     $ curl http://localhost:59881/api/v2/device -H "Content-Type:application/json" -X POST \
       -d '[
             {

--- a/docs_src/microservices/application/AdvancedTopics.md
+++ b/docs_src/microservices/application/AdvancedTopics.md
@@ -166,7 +166,7 @@ The Store and Forward capability allows for export functions to persist data on 
     ```toml
     [Writable.StoreAndForward]
     Enabled = false
-    RetryInterval = '5m'
+    RetryInterval = "5m"
     MaxRetryCount = 10
     ```
 
@@ -181,7 +181,7 @@ Database configuration section describes which database type to use and the info
     Type = "redisdb"
     Host = "localhost"
     Port = 6379
-    Timeout = '30s'
+    Timeout = "30s"
     ```
 
 !!! edgey "EdgeX 2.0"
@@ -226,16 +226,16 @@ All instances of App Services running in secure mode require a SecretStore to be
 !!! example "Example - SecretStore configuration"
     ```toml
     [SecretStore]
-    Type = 'vault'
-    Host = 'localhost'
+    Type = "vault"
+    Host = "localhost"
     Port = 8200
-    Path = 'app-sample/'
-    Protocol = 'http'
-    RootCaCertPath = ''
-    ServerName = ''
-    TokenFile = '/tmp/edgex/secrets/app-sample/secrets-token.json'
+    Path = "app-sample/"
+    Protocol = "http"
+    RootCaCertPath = ""
+    ServerName = ""
+    TokenFile = "/tmp/edgex/secrets/app-sample/secrets-token.json"
       [SecretStore.Authentication]
-      AuthType = 'X-Vault-Token'
+      AuthType = "X-Vault-Token"
     ```
 
 !!! edgey "EdgeX 2.0"
@@ -271,16 +271,16 @@ When running in insecure mode, the secrets are stored and retrieved from the *Wr
     ```toml
        [Writable.InsecureSecrets]    
           [Writable.InsecureSecrets.AWS]
-            Path = 'aws'
+            Path = "aws"
               [Writable.InsecureSecrets.AWS.Secrets]
-              username = 'aws-user'
-              password = 'aws-pw'
+              username = "aws-user"
+              password = "aws-pw"
           
           [Writable.InsecureSecrets.DB]
-            Path = 'redisdb'
+            Path = "redisdb"
               [Writable.InsecureSecrets.DB.Secrets]
-              username = ''
-              password = ''
+              username = ""
+              password = ""
     ```
 
 #### Getting Secrets

--- a/docs_src/microservices/application/AppServiceConfigurable.md
+++ b/docs_src/microservices/application/AppServiceConfigurable.md
@@ -15,7 +15,7 @@ Once the functions have been identified, we'll go ahead and build out the config
 !!! example "Example - Writable.Pipeline"
     ```toml
     [Writable]
-      LogLevel = 'DEBUG'
+      LogLevel = "DEBUG"
       [Writable.Pipeline]
         ExecutionOrder = "FilterByDeviceName, Transform, HTTPExport"
         [Writable.Pipeline.Functions.FilterByDeviceName]
@@ -160,7 +160,7 @@ The default `TargetType` for data flowing into the functions pipeline is an Edge
 !!! example "Example - Configure the functions pipeline to **compress**, **encrypt** and then **export** the `[]byte` data via HTTP "
     ```toml
     [Writable]
-      LogLevel = 'DEBUG'
+      LogLevel = "DEBUG"
       [Writable.Pipeline]
         UseTargetTypeOfByteArray = true
         ExecutionOrder = "Compress, Encrypt, HTTPExport"
@@ -228,7 +228,7 @@ Please refer to the function's detailed documentation by clicking the function n
     ```toml
         [Writable.Pipeline.Functions.BatchByCount]
           [Writable.Pipeline.Functions.BatchByCount.Parameters]
-          Mode = "bytimecount" # can be 'bycount', 'bytime' or 'bytimecount'
+          Mode = "bytimecount" # can be "bycount", "bytime" or "bytimecount"
           BatchThreshold = "30"
           TimeInterval = "60s"
     ```

--- a/docs_src/microservices/application/Triggers.md
+++ b/docs_src/microservices/application/Triggers.md
@@ -38,16 +38,16 @@ The `Type=` is set to `edgex-messagebus` trigger type. The Context function `ctx
 The other piece of configuration required are the connection settings:
 ```toml
 [Trigger.EdgexMessageBus]
-Type = 'redis' # message bus type (i.e 'redis`, `mqtt` or `zero` for ZeroMQ)
+Type = "redis" # message bus type (i.e "redis`, `mqtt` or `zero` for ZeroMQ)
     [Trigger.EdgexMessageBus.SubscribeHost]
-        Host = 'localhost'
+        Host = "localhost"
         Port = 6379
-        Protocol = 'redis'
+        Protocol = "redis"
         SubscribeTopics="edgex/events/#"
     [Trigger.EdgexMessageBus.PublishHost]
-        Host = 'localhost'
+        Host = "localhost"
         Port = 6379
-        Protocol = 'redis'
+        Protocol = "redis"
         PublishTopic="" # optional if publishing response back to the MessageBus
 ```
 
@@ -98,8 +98,8 @@ Type = "mqtt"
     AutoReconnect  = "true"
     ConnectTimeout = "30" # Seconds
     SkipCertVerify = "false"
-    authmode = 'none'  # change to 'usernamepassword', 'clientcert', or 'cacert' for secure MQTT messagebus.
-    secretname = 'mqtt-bus'
+    authmode = "none"  # change to "usernamepassword", "clientcert", or "cacert" for secure MQTT messagebus.
+    secretname = "mqtt-bus"
 
 ```
 

--- a/docs_src/microservices/configuration/CommonEnvironmentVariables.md
+++ b/docs_src/microservices/configuration/CommonEnvironmentVariables.md
@@ -140,12 +140,12 @@ Any configuration setting from a service's `configuration.toml` file can be over
 ~~~toml
 ``` toml   
 TOML   : [Writable]    
-		 LogLevel = 'INFO'    
+		 LogLevel = "INFO"    
 ENVVAR : WRITABLE_LOGLEVEL=DEBUG    
 
 TOML   : [Clients]
   			[Clients.core-data]
-  			Host = 'localhost'
+  			Host = "localhost"
 ENVVAR : CLIENTS_CORE_DATA_HOST=edgex-core-data    
 ```    
 ~~~

--- a/docs_src/microservices/device/V2Migration.md
+++ b/docs_src/microservices/device/V2Migration.md
@@ -18,8 +18,8 @@ The migration of any Device Service's configuration starts with migrating config
 !!! example "Example configuration"
     ```toml
     [Device] 
-    DevicesDir = './res/devices'
-    ProfilesDir = './res/profiles'
+    DevicesDir = "./res/devices"
+    ProfilesDir = "./res/profiles"
     ... 
     ```
  
@@ -45,13 +45,13 @@ A `MessageQueue` section is added in configuration to specify the detail of it.
 !!! example "MessageQueue Example"
 ```toml
 [MessageQueue]
-Protocol = 'redis'
-Host = 'localhost'
+Protocol = "redis"
+Host = "localhost"
 Port = 6379
-Type = 'redis'
-AuthMode = 'usernamepassword'  # required for redis messagebus (secure or insecure).
+Type = "redis"
+AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecure).
 SecretName = "redisdb"
-PublishTopicPrefix = 'edgex/events/device' # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
+PublishTopicPrefix = "edgex/events/device" # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
   [MessageQueue.Optional]
   # Default MQTT Specific options that need to be here to enable environment variable overrides of them
   # Client Identifiers
@@ -239,22 +239,22 @@ In V2 pre-defined devices are in their own file, SDK allows both TOML and JSON f
 !!! example "Pre-defined devices"
     ```toml
     [[DeviceList]]
-    Name = 'Simple-Device01'
-    ProfileName = 'Simple-Device'
-    Description = 'Example of Simple Device'
-    Labels = [ 'industrial' ]
+    Name = "Simple-Device01"
+    ProfileName = "Simple-Device"
+    Description = "Example of Simple Device"
+    Labels = [ "industrial" ]
       [DeviceList.Protocols]
         [DeviceList.Protocols.other]
-        Address = 'simple01'
-        Port = '300'
+        Address = "simple01"
+        Port = "300"
       [[DeviceList.AutoEvents]]
-      Interval = '10s'
+      Interval = "10s"
       OnChange = false
-      SourceName = 'Switch'
+      SourceName = "Switch"
       [[DeviceList.AutoEvents]]
-      Interval = '30s'
+      Interval = "30s"
       OnChange = false
-      SourceName = 'Image'
+      SourceName = "Image"
     ```
 
 Notice that we renamed some fields:  

--- a/docs_src/security/Ch-Configuring-Add-On-Services.md
+++ b/docs_src/security/Ch-Configuring-Add-On-Services.md
@@ -92,16 +92,16 @@ Example:
 
 ```toml
 [SecretStore]
-Type = 'vault'
-Host = 'localhost'
+Type = "vault"
+Host = "localhost"
 Port = 8200
-Path = 'device-camera/'
-Protocol = 'http'
-RootCaCertPath = ''
-ServerName = ''
-TokenFile = '/tmp/edgex/secrets/device-camera/secrets-token.json'
+Path = "device-camera/"
+Protocol = "http"
+RootCaCertPath = ""
+ServerName = ""
+TokenFile = "/tmp/edgex/secrets/device-camera/secrets-token.json"
   [SecretStore.Authentication]
-  AuthType = 'X-Vault-Token'
+  AuthType = "X-Vault-Token"
 ```
 
 Note that the service key `device-camera` must be used for the `Path` and in the `TokenFile` path

--- a/docs_src/security/security-file-token-provider.1.md
+++ b/docs_src/security/security-file-token-provider.1.md
@@ -47,10 +47,10 @@ parameters used for Vault token generation.
     Port = 8200 
 
     [TokenFileProvider]
-    PrivilegedTokenPath = /run/edgex/secrets/security-file-token-provider/secrets-token.json
-    ConfigFile = token-config.json
-    OutputDir = /run/edgex/secrets/
-    OutputFilename = secrets-token.json
+    PrivilegedTokenPath = "/run/edgex/secrets/security-file-token-provider/secrets-token.json"
+    ConfigFile = "token-config.json"
+    OutputDir = "/run/edgex/secrets/"
+    OutputFilename = "secrets-token.json"
 
 ## secrets-token.json
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
TOML examples have single quotes or mix of single and double quotes

## Issue Number:  #539


## What is the new behavior?
TOML examples now have just double quotes
Also update some examples to have proper tags like `toml`, `yaml`, etc

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information