### PR TITLE
fix: fixed incorrect URL for core-data query

### DIFF
--- a/docs_src/getting-started/Ch-GettingStartedSDK-C.md
+++ b/docs_src/getting-started/Ch-GettingStartedSDK-C.md
@@ -214,7 +214,7 @@ sends to EdgeX.
 6.  Using a browser, enter the following URL to see the event/reading
     data that the service is generating and sending to EdgeX:
 
-    <http://localhost:59880/api/v2/event/device/RandNum-Device01/100>
+    <http://localhost:59880/api/v2/event/device/name/RandNum-Device01?limit=100>
 
     This request asks core data to provide the last 100 events/readings associated to the RandNum-Device-01.
 


### PR DESCRIPTION
Signed-off-by: Iain Anderson <iain@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Guide for C device SDK contains a core-data URL which is not correctly changed for the v2 API
## Issue Number:


## What is the new behavior?
corrected URL

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information