### PR TITLE
fix: small clarifications for device-sdk-c (#558)

### DIFF
--- a/docs_src/getting-started/Ch-GettingStartedCDevelopers.md
+++ b/docs_src/getting-started/Ch-GettingStartedCDevelopers.md
@@ -20,17 +20,18 @@ guide](./Ch-GettingStartedDevelopers.md), to build EdgeX C services, you will ne
 -   libuuid
 -   hiredis
 
-You can install these on Ubuntu by running:
+You can install these on Ubuntu (20.04 LTS) by running:
 ``` bash
 sudo apt-get install libcurl4-openssl-dev libmicrohttpd-dev libyaml-dev libcbor-dev libpaho-mqtt uuid-dev libhiredis-dev
 ```
+Some of these supporting packages have dependencies of their own, which will be automatically installed when using package managers such as `apt`, `yum` etc.
 
 !!! edgey "EdgeX 2.0"
     For EdgeX 2.0 the C SDK now supports MQTT and Redis implementations of the EdgeX MessageBus
 
 CMake is required to build the SDKs.  Version 3 or better is required.  You can install CMake on Ubuntu by running:
 ``` bash
-sudo apt install cmake
+sudo apt-get install cmake
 ```
 
 Check that your C development environment includes the following:

--- a/docs_src/getting-started/Ch-GettingStartedSDK-C.md
+++ b/docs_src/getting-started/Ch-GettingStartedSDK-C.md
@@ -117,6 +117,8 @@ for (uint32_t i = 0; i < nreadings; i++)
 return true;
 ```
 
+Here the reading value is set to a random signed integer. Various `iot_data_alloc_` functions are defined in the `iot/data.h` header allowing readings of different types to be generated.
+
 ## Creating your Device Profile
 
 A device profile is a YAML file that describes a class of device to


### PR DESCRIPTION
Signed-off-by: Iain Anderson <iain@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Discussion of C SDK dependencies refers to Ubuntu without specifying a version

## Issue Number: #558 


## What is the new behavior?

- Ubuntu specified as the 20.04 LTS release
- Added note on dependencies of dependencies
- Removed inconsistent use of `apt` and `apt-get`
- Added note on returning reading values

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information