### PR TITLE
feat: Update common SecretStore config for V2

### DIFF
--- a/docs_src/microservices/configuration/CommonConfiguration.md
+++ b/docs_src/microservices/configuration/CommonConfiguration.md
@@ -15,7 +15,7 @@ The tables in each of the tabs below document configuration properties that are 
     |||entries in the Writable section of the configuration can be changed on the fly while the service is running if the service is running with the `-cp/--configProvider` flag|
     |LogLevel|INFO|log entry [severity level](https://en.wikipedia.org/wiki/Syslog#Severity_level).  Log entries not of the default level or higher are ignored.|
     |**InsecureSecrets**|---|This section a map of secrets which simulates the SecretStore for accessing secrets when running in non-secure mode. All services have a default entry for Redis DB credentials called `redisdb`|
-
+    
     !!! edgey "Edgex 2.0"
         For EdgeX 2.0 the For EdgeX 2.0 the `Writable.InsecureSecrets` configuration section is new. 
 
@@ -31,7 +31,7 @@ The tables in each of the tabs below document configuration properties that are 
     |MaxResultCount|50000|Read data limit per invocation|
     |MaxRequestSize|0|Defines the maximum size of http request body in bytes. 0 represents default to system max. Not all services actual implement this setting. Those that do not have a comment stating this fact.|
     |RequestTimeout         |5s                          | Specifies a timeout duration for handling requests |
-
+    
     !!! edgey "Edgex 2.0"
         For EdgeX 2.0 `Protocol` and `BootTimeout`  have been removed. `CheckInterval` and  `Timeout ` have been renamed to `HealthCheckInterval` and `RequestTimeout` respectively. `MaxRequestSize` was added for all services.
 
@@ -45,7 +45,7 @@ The tables in each of the tabs below document configuration properties that are 
     |Name      |----                       |Database or document store name (Specific to the service)            |
     |Timeout      |5000                           |DB connection timeout                                              |
     |Type |redisdb                        |DB type.  Redis is the only supported DB|
-
+    
     !!! edgey "Edgex 2.0"
         For EdgeX 2.0 `mongodb` has been remove as a supported DB. The credentials `username` and `password` have been removed and are now in the `Writable.InsecureSecrets.DB` section.
 
@@ -66,7 +66,7 @@ The tables in each of the tabs below document configuration properties that are 
     |Protocol | http  | The protocol to use when building a URI to local the service endpoint|
     |Host | localhost  | The host name or IP address where the service is hosted |
     |Port | 598xx | The port exposed by the target service|
-
+    
     !!! edgey "Edgex 2.0"
         For EdgeX 2.0 the map keys have changed to be the service's service-key, i.e. `Metadata` changed to `core-metadata`
 
@@ -74,18 +74,19 @@ The tables in each of the tabs below document configuration properties that are 
 
     |Property|Default Value|Description|
     |---|---|---|
-    |||these config values are used when security is enabled and Vault access is required for obtaining secrets, such as database credentials|
-    |Host | localhost  | The host name or IP address associated with Vault|
-    |Port | 8200  | The configured port on which Vault is listening|
+    |||these config values are used when security is enabled and `SecretStore` service access is required for obtaining secrets, such as database credentials|
+    |Type | vault  | The type of the `SecretStore` service to use. Currenly only `vault` is supported.|
+    |Host | localhost  | The host name or IP address associated with the `SecretStore` service|
+    |Port | 8200  | The configured port on which the `SecretStore` service is listening|
     |Path | /`<service-key>` | The service-specific path where the secrets are kept. This path will differ according to the given service. |
-    |Protocol | http  | The protocol to be used when communicating with Vault|
+    |Protocol | http  | The protocol to be used when communicating with the `SecretStore` service|
     |RootCaCertPath | blank | Default is to not use HTTPS |
     |ServerName | blank | Not needed for HTTP |
-    |TokenFile | /tmp/edgex/secrets/`<service-key>`/secrets-token.json | Fully-qualified path to the location of the Vault root token. This path will differ according to the given service. |
+    |TokenFile | /tmp/edgex/secrets/`<service-key>`/secrets-token.json | Fully-qualified path to the location of the service's `SecretStore` acc token. This path will differ according to the given service. |
     |AdditionalRetryAttempts | 10  | Number of attempts to retry retrieving secrets before failing to start the service |
-    |RetryWaitPeriod | 1s  | Amount of time to wait before attempting another connection to Vault|
-    |Authentication AuthType | X-Vault-Token  | A header used to indicate how the given service will authenticate with Vault|
-
+    |RetryWaitPeriod | 1s  | Amount of time to wait before attempting another connection to the `SecretStore` service|
+    |Authentication AuthType | X-Vault-Token  | A header used to indicate how the given service will authenticate with the `SecretStore` service|
+    
     !!! edgey "Edgex 2.0"
         For EdgeX 2.0 the `Protocol` default has changed to `HTTP` which no longer requires `RootCaCertPath` and `ServerName` to be set. `Path` has been reduce to the sub-path for the service since the based path is fixed. `TokenFile` default value has changed and requires the `service-key` be used in the path.
 

--- a/docs_src/microservices/configuration/CommonConfiguration.md
+++ b/docs_src/microservices/configuration/CommonConfiguration.md
@@ -78,13 +78,11 @@ The tables in each of the tabs below document configuration properties that are 
     |Type | vault  | The type of the `SecretStore` service to use. Currenly only `vault` is supported.|
     |Host | localhost  | The host name or IP address associated with the `SecretStore` service|
     |Port | 8200  | The configured port on which the `SecretStore` service is listening|
-    |Path | /`<service-key>` | The service-specific path where the secrets are kept. This path will differ according to the given service. |
+    |Path | `<service-key>`/ | The service-specific path where the secrets are kept. This path will differ according to the given service. |
     |Protocol | http  | The protocol to be used when communicating with the `SecretStore` service|
     |RootCaCertPath | blank | Default is to not use HTTPS |
     |ServerName | blank | Not needed for HTTP |
-    |TokenFile | /tmp/edgex/secrets/`<service-key>`/secrets-token.json | Fully-qualified path to the location of the service's `SecretStore` acc token. This path will differ according to the given service. |
-    |AdditionalRetryAttempts | 10  | Number of attempts to retry retrieving secrets before failing to start the service |
-    |RetryWaitPeriod | 1s  | Amount of time to wait before attempting another connection to the `SecretStore` service|
+    |TokenFile | /tmp/edgex/secrets/`<service-key>`/secrets-token.json | Fully-qualified path to the location of the service's `SecretStore` access token. This path will differ according to the given service. |
     |Authentication AuthType | X-Vault-Token  | A header used to indicate how the given service will authenticate with the `SecretStore` service|
     
     !!! edgey "Edgex 2.0"


### PR DESCRIPTION
Common SecretStore config was out-of-date for V2. It is now up-to-date

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)

