### PR TITLE
fix: dependency installation for C development

### DIFF
--- a/docs_src/getting-started/Ch-GettingStartedCDevelopers.md
+++ b/docs_src/getting-started/Ch-GettingStartedCDevelopers.md
@@ -20,16 +20,25 @@ guide](./Ch-GettingStartedDevelopers.md), to build EdgeX C services, you will ne
 -   libuuid
 -   hiredis
 
-You can install these on Ubuntu (20.04 LTS) by running:
+You can install these on Debian 11 (Bullseye) by running:
 ``` bash
-sudo apt-get install libcurl4-openssl-dev libmicrohttpd-dev libyaml-dev libcbor-dev libpaho-mqtt uuid-dev libhiredis-dev
+sudo apt-get install libcurl4-openssl-dev libmicrohttpd-dev libyaml-dev libcbor-dev libpaho-mqtt-dev uuid-dev libhiredis-dev
 ```
 Some of these supporting packages have dependencies of their own, which will be automatically installed when using package managers such as *APT*, *DNF* etc.
+
+`libpaho-mqtt-dev` is not included in Ubuntu prior to Groovy (20.10). IOTech provides a package for Focal (20.04 LTS) which may be installed as follows:
+
+``` bash
+sudo curl -fsSL https://iotech.jfrog.io/artifactory/api/gpg/key/public -o /etc/apt/trusted.gpg.d/iotech-public.asc
+sudo echo "deb https://iotech.jfrog.io/iotech/debian-release $(lsb_release -cs) main" | tee -a /etc/apt/sources.list.d/iotech.list
+sudo apt-get update
+sudo apt-get install libpaho-mqtt
+```
 
 !!! edgey "EdgeX 2.0"
     For EdgeX 2.0 the C SDK now supports MQTT and Redis implementations of the EdgeX MessageBus
 
-CMake is required to build the SDKs.  Version 3 or better is required.  You can install CMake on Ubuntu by running:
+CMake is required to build the SDKs.  Version 3 or better is required.  You can install CMake on Debian by running:
 ``` bash
 sudo apt-get install cmake
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Command suggested for installing the supporting libraries needed by the C SDK does not work

## Issue Number:


## What is the new behavior?
Specified a working command for current Debian. Noted the lack of required MQTT package in the latest Ubuntu LTS and documented how to install IOTech's build of it.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information