### PR TITLE
feat: Document new Seeding Service Secrets capability

### DIFF
--- a/docs_src/microservices/configuration/CommonConfiguration.md
+++ b/docs_src/microservices/configuration/CommonConfiguration.md
@@ -51,6 +51,7 @@ The tables in each of the tabs below document configuration properties that are 
 
 === "Registry"
     
+
     |Property|Default Value|Description|
     |---|---|---|
     |||this configuration only takes effect when connecting to the registry for configuration info|
@@ -83,6 +84,7 @@ The tables in each of the tabs below document configuration properties that are 
     |RootCaCertPath | blank | Default is to not use HTTPS |
     |ServerName | blank | Not needed for HTTP |
     |TokenFile | /tmp/edgex/secrets/`<service-key>`/secrets-token.json | Fully-qualified path to the location of the service's `SecretStore` access token. This path will differ according to the given service. |
+    |SecretsFile| blank | Fully-qualified path to the location of the service's JSON secrets file contains secrets to seed at start-up. See [Seeding Service Secrets](../../security/SeedingServiceSecrets.md) section for more details on seed a service's secrets. |
     |Authentication AuthType | X-Vault-Token  | A header used to indicate how the given service will authenticate with the `SecretStore` service|
     
     !!! edgey "Edgex 2.0"

--- a/docs_src/microservices/configuration/CommonConfiguration.md
+++ b/docs_src/microservices/configuration/CommonConfiguration.md
@@ -84,6 +84,8 @@ The tables in each of the tabs below document configuration properties that are 
     |ServerName | blank | Not needed for HTTP |
     |TokenFile | /tmp/edgex/secrets/`<service-key>`/secrets-token.json | Fully-qualified path to the location of the service's `SecretStore` access token. This path will differ according to the given service. |
     |SecretsFile| blank | Fully-qualified path to the location of the service's JSON secrets file  contains secrets to seed at start-up. See [Seeding Service Secrets](../../security/SeedingServiceSecrets.md) section for more details on seed a service's secrets. |
+    |DisableScrubSecretsFile| false | Controls if the secrets file is scrubbed (secret data remove) and rewritten after importing the secrets.|
+    
     |Authentication AuthType | X-Vault-Token  | A header used to indicate how the given service will authenticate with the `SecretStore` service|
     
     !!! edgey "Edgex 2.0"

--- a/docs_src/microservices/configuration/CommonConfiguration.md
+++ b/docs_src/microservices/configuration/CommonConfiguration.md
@@ -50,7 +50,6 @@ The tables in each of the tabs below document configuration properties that are 
         For EdgeX 2.0 `mongodb` has been remove as a supported DB. The credentials `username` and `password` have been removed and are now in the `Writable.InsecureSecrets.DB` section.
 
 === "Registry"
-    
 
     |Property|Default Value|Description|
     |---|---|---|
@@ -84,7 +83,7 @@ The tables in each of the tabs below document configuration properties that are 
     |RootCaCertPath | blank | Default is to not use HTTPS |
     |ServerName | blank | Not needed for HTTP |
     |TokenFile | /tmp/edgex/secrets/`<service-key>`/secrets-token.json | Fully-qualified path to the location of the service's `SecretStore` access token. This path will differ according to the given service. |
-    |SecretsFile| blank | Fully-qualified path to the location of the service's JSON secrets file contains secrets to seed at start-up. See [Seeding Service Secrets](../../security/SeedingServiceSecrets.md) section for more details on seed a service's secrets. |
+    |SecretsFile| blank | Fully-qualified path to the location of the service's JSON secrets file  contains secrets to seed at start-up. See [Seeding Service Secrets](../../security/SeedingServiceSecrets.md) section for more details on seed a service's secrets. |
     |Authentication AuthType | X-Vault-Token  | A header used to indicate how the given service will authenticate with the `SecretStore` service|
     
     !!! edgey "Edgex 2.0"

--- a/docs_src/security/SeedingServiceSecrets.md
+++ b/docs_src/security/SeedingServiceSecrets.md
@@ -1,0 +1,88 @@
+# Seeding Service Secrets
+
+!!! edgey "EdgeX 2.1"
+    New for EdgeX 2.1 is the ability to seed service specific secrets during the service's start-up. 
+
+All EdgeX services now have the capability to specify a JSON file that contains the service's secrets which are seeded into the service's `SecretStore` during service start-up. This allows the secrets to be present in the service's `SecretStore` when the service needs to use them.
+
+The new `SecretsFile` setting on the `SecretStore` configuration allows the service to specify the fully-qualified path to the location of the service's secrets file. Normally this setting is left blank when a service has no secrets to be seeded.
+
+!!! example "Example setting SecretsFilePath in TOML"
+
+    ```toml
+    [SecretStore]
+    Type = "vault"
+    ...
+    SecretsFile = "/tmp/my-service/secrets.json"
+    ...
+    ```
+
+This setting can also be overriding with the `SECRETSTORE_SECRETSFILE` environment variable in the docker-compose file and then volume mounted in to the service's container.
+
+!!! example "Example setting SecretsFilePath via environment override"
+    ```yaml
+    environment:
+      SECRETSTORE_SECRETSFILEPATH: "/tmp/my-service/secrets.json"
+      ...
+    volumes:
+    - /tmp/my-service/secrets.json:/tmp/my-service/secrets.json
+    ```
+
+During service start-up, after `SecretStore` initialization, the service's secrets JSON file is read, validated and the secrets stored into the service's `SecretStore`. The file is then rewrite without the sensitive secret data that was successfully stored. 
+
+!!! Example "Example of initial service secrets JSON"
+    ```json
+    {
+        "secrets": [
+            {
+                "path": "credentials001",
+                "imported": false,
+                "secretData": [
+                    {
+                        "key": "username",
+                        "value": "my-user-1"
+                    },
+                                    {
+                        "key": "password",
+                        "value": "password-001"
+                    }
+                ]
+            },
+            {
+                "path": "credentials002",
+                "imported": false,
+                "secretData": [
+                    {
+                        "key": "username",
+                        "value": "my-user-2"
+                    },
+                                    {
+                        "key": "password",
+                        "value": "password-002"
+                    }
+                ]
+            }
+        ]
+    }
+    ```
+
+!!! Example "Example of re-written service secrets JSON after seeding complete"
+    ```json
+    {
+        "secrets": [
+            {
+                "path": "credentials001",
+                "imported": true,
+                "secretData": []
+            },
+            {
+                "path": "credentials002",
+                "imported": true,
+                "secretData": []
+            }
+        ]
+    }
+    ```
+
+The secrets marked with `imported=true` are ignored the next time the service starts up since they are already in the the service's `SecretStore`.  If the Secret Store service's persistence is cleared, the original version of service's secrets file will need to be provided for the next time the service starts up.
+

--- a/docs_src/security/SeedingServiceSecrets.md
+++ b/docs_src/security/SeedingServiceSecrets.md
@@ -14,7 +14,7 @@ All EdgeX services now have the capability to specify a JSON file that contains 
 
 The new `SecretsFile` setting on the `SecretStore` configuration allows the service to specify the fully-qualified path to the location of the service's secrets file. Normally this setting is left blank when a service has no secrets to be seeded.
 
-!!! example "Example - Setting SecretsFilePath in TOML"
+!!! example "Example - Setting SecretsFile in TOML"
 
     ```toml
     [SecretStore]

--- a/docs_src/security/SeedingServiceSecrets.md
+++ b/docs_src/security/SeedingServiceSecrets.md
@@ -5,6 +5,9 @@
 
 All EdgeX services now have the capability to specify a JSON file that contains the service's secrets which are seeded into the service's `SecretStore` during service start-up. This allows the secrets to be present in the service's `SecretStore` when the service needs to use them.
 
+!!! note
+    The service must already have a `SecretStore` configured. This is done by default for the Core/Support services. See [Configure the service's Secret Store](../Ch-Configuring-Add-On-Services/#configure-the-services-secret-store-to-use) section for details for add-on App and Device services 
+
 The new `SecretsFile` setting on the `SecretStore` configuration allows the service to specify the fully-qualified path to the location of the service's secrets file. Normally this setting is left blank when a service has no secrets to be seeded.
 
 !!! example "Example setting SecretsFilePath in TOML"
@@ -17,18 +20,18 @@ The new `SecretsFile` setting on the `SecretStore` configuration allows the serv
     ...
     ```
 
-This setting can also be overriding with the `SECRETSTORE_SECRETSFILE` environment variable in the docker-compose file and then volume mounted in to the service's container.
+This setting can also be overridden with the `SECRETSTORE_SECRETSFILE` environment variable. When EdgeX is deployed using Docker/docker-compose the setting can be overridden in the docker-compose file and the file can be volume mounted into the service's container.
 
-!!! example "Example setting SecretsFilePath via environment override"
+!!! example "Example setting SecretsFile via environment override"
     ```yaml
     environment:
-      SECRETSTORE_SECRETSFILEPATH: "/tmp/my-service/secrets.json"
+      SECRETSTORE_SECRETSFILE: "/tmp/my-service/secrets.json"
       ...
     volumes:
     - /tmp/my-service/secrets.json:/tmp/my-service/secrets.json
     ```
 
-During service start-up, after `SecretStore` initialization, the service's secrets JSON file is read, validated and the secrets stored into the service's `SecretStore`. The file is then rewrite without the sensitive secret data that was successfully stored. 
+During service start-up, after `SecretStore` initialization, the service's secrets JSON file is read, validated, and the secrets stored into the service's `SecretStore`. The file is then rewritten without the sensitive secret data that was successfully stored. 
 
 !!! Example "Example of initial service secrets JSON"
     ```json

--- a/docs_src/security/SeedingServiceSecrets.md
+++ b/docs_src/security/SeedingServiceSecrets.md
@@ -8,21 +8,26 @@ All EdgeX services now have the capability to specify a JSON file that contains 
 !!! note
     The service must already have a `SecretStore` configured. This is done by default for the Core/Support services. See [Configure the service's Secret Store](../Ch-Configuring-Add-On-Services/#configure-the-services-secret-store-to-use) section for details for add-on App and Device services 
 
+
+
+## Secrets File
+
 The new `SecretsFile` setting on the `SecretStore` configuration allows the service to specify the fully-qualified path to the location of the service's secrets file. Normally this setting is left blank when a service has no secrets to be seeded.
 
-!!! example "Example setting SecretsFilePath in TOML"
+!!! example "Example - Setting SecretsFilePath in TOML"
 
     ```toml
     [SecretStore]
     Type = "vault"
     ...
     SecretsFile = "/tmp/my-service/secrets.json"
+    DisableScrubSecretsFile = false
     ...
     ```
 
 This setting can also be overridden with the `SECRETSTORE_SECRETSFILE` environment variable. When EdgeX is deployed using Docker/docker-compose the setting can be overridden in the docker-compose file and the file can be volume mounted into the service's container.
 
-!!! example "Example setting SecretsFile via environment override"
+!!! example "Example - Setting SecretsFile via environment override"
     ```yaml
     environment:
       SECRETSTORE_SECRETSFILE: "/tmp/my-service/secrets.json"
@@ -31,9 +36,9 @@ This setting can also be overridden with the `SECRETSTORE_SECRETSFILE` environme
     - /tmp/my-service/secrets.json:/tmp/my-service/secrets.json
     ```
 
-During service start-up, after `SecretStore` initialization, the service's secrets JSON file is read, validated, and the secrets stored into the service's `SecretStore`. The file is then rewritten without the sensitive secret data that was successfully stored. 
+During service start-up, after `SecretStore` initialization, the service's secrets JSON file is read, validated, and the secrets stored into the service's `SecretStore`. The file is then scrubbed of the secret data, i.e rewritten without the sensitive secret data that was successfully stored. See [Disable Scrubbing](#disable-scrubbing) section below for detail on disabling the scrubbing of the secret data
 
-!!! Example "Example of initial service secrets JSON"
+!!! example "Example - Initial service secrets JSON"
     ```json
     {
         "secrets": [
@@ -69,7 +74,7 @@ During service start-up, after `SecretStore` initialization, the service's secre
     }
     ```
 
-!!! Example "Example of re-written service secrets JSON after seeding complete"
+!!! example "Example - Re-written service secrets JSON after seeding complete"
     ```json
     {
         "secrets": [
@@ -89,3 +94,25 @@ During service start-up, after `SecretStore` initialization, the service's secre
 
 The secrets marked with `imported=true` are ignored the next time the service starts up since they are already in the the service's `SecretStore`.  If the Secret Store service's persistence is cleared, the original version of service's secrets file will need to be provided for the next time the service starts up.
 
+!!! note
+    The secrets file must be have write permissions for the file to be scrubbed of the secret data. If not the service with fail to start-up with an error re-writing the file.
+
+## Disable Scrubbing 
+
+Scrubbing of the secret data can be disabled by setting `SecretStore.DisableScrubSecretsFile` to `true`. This can be done in the configuration.toml file or by using the `SECRETSTORE_DISABLESCRUBSECRETSFILE` environment variable override. 
+
+!!! example "Example - Set DisableScrubSecretsFile in TOML"
+    ```toml
+    [SecretStore]
+    Type = "vault"
+    ...
+    SecretsFile = "/tmp/my-service/secrets.json"
+    DisableScrubSecretsFile = true
+    ...
+    ```
+
+!!! example "Example - Set DisableScrubSecretsFile via environment variable"
+    ```yaml
+    environment:
+      SECRETSTORE_DISABLESCRUBSECRETSFILE: "true"
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - './security/Ch-SecurityIssues.md'
     - './security/secrets-config.md'
     - './security/secrets-config-proxy.md'
+    - './security/SeedingServiceSecrets.md'
   - Microservices:
       - './microservices/general/index.md'
       - Configuration & Registry:


### PR DESCRIPTION
closes #586

related to https://github.com/edgexfoundry/edgex-docs/pull/587

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/gedgex-docs/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/CONTRIBUTING.md -->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
