### PR TITLE
build: Switch to Jakarta for documentation development

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: EdgeX Foundry Documentation
 docs_dir: ./docs_src
-site_dir: ./docs/2.0
+site_dir: ./docs/2.1
 site_description: 'Documentation for use of EdgeX Foundry'
 site_author: 'Michael Johanson'
 site_url: 'https://edgexfoundry.github.io/edgex-docs/'

--- a/versions.json
+++ b/versions.json
@@ -2,5 +2,6 @@
     {"version": "1.1", "title": "1.1-Fuji", "aliases": []},
     {"version": "1.2", "title": "1.2-Geneva", "aliases": []},
     {"version": "1.3", "title": "1.3-Hanoi", "aliases": []},
-    {"version": "2.0", "title": "2.0-Ireland", "aliases": []}
+    {"version": "2.0", "title": "2.0-Ireland", "aliases": []},
+    {"version": "2.1", "title": "2.1-Jakarta", "aliases": []}
 ]


### PR DESCRIPTION
Default drop down will still be 2.0-Ireland.
2.1-Jakarta will now be in the drop down and any merges into `main` will show up there.

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/CONTRIBUTING.md -->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README) **N/A**
