### PR TITLE
fix(microservices): Correct metadata default config

### DIFF
--- a/docs_src/microservices/core/metadata/Ch-Metadata.md
+++ b/docs_src/microservices/core/metadata/Ch-Metadata.md
@@ -354,11 +354,10 @@ Please refer to the general [Common Configuration documentation](../../configura
 |Property|Default Value|Description|
 |---|---|---|
 |||Configuration to post device changes through the notifiction service|
-|PostDeviceChanges|true|Whether to send out notification when a device has been added, changed, or removed|
-|Slug|'device-change-'|Notification service slug to use in sending notification messages|
-|Content|'Device update: '|Start of the notification message when sending notification messages on device change|
+|PostDeviceChanges|false|Whether to send out notification when a device has been added, changed, or removed|
+|Content|'Meatadata notice: '|Start of the notification message when sending notification messages on device change|
 |Sender|'core-metadata'|Sender of any notification messages sent on device change|
-|Description|'Metadata device notice'|Message description of any notification messages sent on device change|
+|Description|'Metadata change notice'|Message description of any notification messages sent on device change|
 |Label|'metadata'|Label to put on messages for any notification messages sent on device change|
 
 


### PR DESCRIPTION
Change Notifications.PostDeviceChanges default value to false, and
correct to Notifications related config default value to meet the
current v2 design on Core Metadata page.

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
