### PR TITLE
feat: Document Device Service Publish to MessageBus default capability

### DIFF
--- a/docs_src/microservices/core/data/Ch-CoreData.md
+++ b/docs_src/microservices/core/data/Ch-CoreData.md
@@ -117,34 +117,38 @@ The two following High Level Interaction Diagrams show:
 Please refer to the general [Common Configuration documentation](../../configuration/CommonConfiguration.md) for configuration properties common to all services. Below are only the additional settings and sections that are not common to all EdgeX Services.
 
 === "Writable"
-|Property|Default Value|Description|
-|---|---|---|
-||Writable properties can be set and will dynamically take effect without service restart|
-|PersistData|true|When true, core data persists all sensor data sent to it in its associated database|
+    |Property|Default Value|Description|
+    |---|---|---|
+    ||Writable properties can be set and will dynamically take effect without service restart|
+    |PersistData|true|When true, core data persists all sensor data sent to it in its associated database|
 === "Databases/Databases.Primary"
-|Property|Default Value|Description|
-|---|---|---|
-|Name|'coredata'|Document store or database name|
+    |Property|Default Value|Description|
+    |---|---|---|
+    |Name|'coredata'|Document store or database name|
 === "MessageQueue"
-|Property|Default Value|Description|
-|---|---|---|
-||Entries in the MessageQueue section of the configuration allow for publication of events to a message bus|
-|Protocol | redis| Indicates the connectivity protocol to use to use the bus.|
-|Host | localhost | Indicates the host of the messaging broker, if applicable.|
-|Port | 6379| Indicates the port to use when publishing a message.|
-|Type | redis| Indicates the type of messaging library to use. Currently this is Redis by default. Refer to the [go-mod-messaging](https://github.com/edgexfoundry/go-mod-messaging) module for more information. |
-|PublishTopicPrefix | edgex/events/core| Indicates the base topic to which messages should be published. /`<device-profile-name>/<device-name>` will be added to this Publish Topic prefix|
+    |Property|Default Value|Description|
+    |---|---|---|
+    ||Entries in the MessageQueue section of the configuration allow for publication of events to a message bus|
+    |Protocol | redis| Indicates the connectivity protocol to use to use the bus.|
+    |Host | localhost | Indicates the host of the messaging broker, if applicable.|
+    |Port | 6379| Indicates the port to use when publishing a message.|
+    |Type | redis| Indicates the type of messaging library to use. Currently this is Redis by default. Refer to the [go-mod-messaging](https://github.com/edgexfoundry/go-mod-messaging) module for more information. |
+    |AuthMode | usernamepassword| Auth Mode to connect to EdgeX MessageBUs.|
+    |SecretName | redisdb | Name of the secret in the Secret Store to find the MessageBus credentials.|
+    |PublishTopicPrefix | edgex/events/core| Indicates the base topic to which messages should be published. /`<device-profile-name>/<device-name>` will be added to this Publish Topic prefix|
+    |SubscribeEnabled | true | Indicates wether to subcribe to the EdgeX MessageBus or not.|
+    |SubscribeTopic | edgex/events/device/# | Topis to use when subscribing to the EdgeX MessageBus|
 === "MessageQueue.Optional"
-|Property|Default Value|Description|
-|---|---|---|
-||Configuration and connection parameters for use with MQTT message bus - in place of Redis|
-|ClientId|'core-data'|Client ID used to put messages on the bus|
-|Qos|'0'| Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)|
-|KeepAlive |'10'| Period of time in seconds to keep the connection alive when there is no messages flowing (must be 2 or greater)|
-|Retained|false|Whether to retain messages|
-|AutoReconnect |true |Whether to reconnect to the message bus on connection loss|
-|ConnectTimeout|5|Message bus connection timeout in seconds|
-|SkipCertVerify|false|TLS configuration - Only used if Cert/Key file or Cert/Key PEMblock are specified|
+    |Property|Default Value|Description|
+    |---|---|---|
+    ||Configuration and connection parameters for use with MQTT message bus - in place of Redis|
+    |ClientId|'core-data'|Client ID used to put messages on the bus|
+    |Qos|'0'| Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)|
+    |KeepAlive |'10'| Period of time in seconds to keep the connection alive when there is no messages flowing (must be 2 or greater)|
+    |Retained|false|Whether to retain messages|
+    |AutoReconnect |true |Whether to reconnect to the message bus on connection loss|
+    |ConnectTimeout|5|Message bus connection timeout in seconds|
+    |SkipCertVerify|false|TLS configuration - Only used if Cert/Key file or Cert/Key PEMblock are specified|
 
 ### V2 Configuration Migration Guide
 

--- a/docs_src/microservices/device/Ch-DeviceServices.md
+++ b/docs_src/microservices/device/Ch-DeviceServices.md
@@ -133,6 +133,28 @@ Please refer to the general [Common Configuration documentation](../configuratio
     |UseMessageBus|true|Controls whether events are published via MessageBus or core-data (REST)|
     |Discovery/Enabled|true|Controls whether device discovery is enabled|
     |Discovery/Interval|0|Interval between automatic discovery runs. Zero means do not run discovery automatically|
+=== "MessageQueue"
+    |Property|Default Value|Description|
+    |---|---|---|
+    ||Entries in the MessageQueue section of the configuration allow for publication of events to a message bus|
+    |Protocol | redis| Indicates the connectivity protocol to use to use the bus.|
+    |Host | localhost | Indicates the host of the messaging broker, if applicable.|
+    |Port | 6379| Indicates the port to use when publishing a message.|
+    |Type | redis| Indicates the type of messaging library to use. Currently this is Redis by default. Refer to the [go-mod-messaging](https://github.com/edgexfoundry/go-mod-messaging) module for more information. |
+    |AuthMode | usernamepassword| Auth Mode to connect to EdgeX MessageBus.|
+    |SecretName | redisdb | Name of the secret in the Secret Store to find the MessageBus credentials.|
+    |PublishTopicPrefix | edgex/events/device| Indicates the base topic to which messages should be published. /`<device-profile-name>/<device-name>` will be added to this Publish Topic prefix|
+=== "MessageQueue.Optional"
+    |Property|Default Value|Description|
+    |---|---|---|
+    ||Configuration and connection parameters for use with MQTT message bus - in place of Redis|
+    |ClientId|[service-key]|Client ID used to put messages on the bus|
+    |Qos|'0'| Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)|
+    |KeepAlive |'10'| Period of time in seconds to keep the connection alive when there is no messages flowing (must be 2 or greater)|
+    |Retained|false|Whether to retain messages|
+    |AutoReconnect |true |Whether to reconnect to the message bus on connection loss|
+    |ConnectTimeout|5|Message bus connection timeout in seconds|
+    |SkipCertVerify|false|TLS configuration - Only used if Cert/Key file or Cert/Key PEMblock are specified|
 
 ### Custom Configuration
 

--- a/docs_src/microservices/device/Ch-DeviceServices.md
+++ b/docs_src/microservices/device/Ch-DeviceServices.md
@@ -109,6 +109,13 @@ Device services support one additional command-line argument, `--instance` or `-
 
 For example, running `device-modbus -i 1` results in a service named `device-modbus_1`, ie the parameter given to the `instance` argument is added as a suffix to the device service name. The same effect may be obtained by setting the `EDGEX_INSTANCE` environment variable.
 
+## Publish to MessageBus
+
+!!! edgey "Edgex 2.0"
+    New in Edgex 2.0
+
+Device services now have the capability to publish Events directly to the EdgeX MessageBus, rather than POST the Events to Core Data via REST. This capability is controlled by the `Device.UseMessageBus` configuration property (see below), which is set to `true` by default. Core Data is configured by default to subscribe to the EdgeX MessageBus to receive and persist the Events. Application services, as in EdgeX 1.x, subscribe to the EdgeX MessageBus to receive and process the Events.
+
 ## Configuration Properties
 
 Please refer to the general [Common Configuration documentation](../configuration/CommonConfiguration.md) for configuration properties common to all services.
@@ -123,7 +130,7 @@ Please refer to the general [Common Configuration documentation](../configuratio
     |ProfilesDir|''|If set, directory containing profile definition files to upload to core-metadata|
     |DevicesDir|''|If set, directory containing device definition files to upload to core-metadata|
     |UpdateLastConnected|false|If true, update the LastConnected attribute of a device whenever it is successfully accessed|
-    |UseMessageBus|false|Controls whether events are published via MessageBus or core-data (REST)|
+    |UseMessageBus|true|Controls whether events are published via MessageBus or core-data (REST)|
     |Discovery/Enabled|true|Controls whether device discovery is enabled|
     |Discovery/Interval|0|Interval between automatic discovery runs. Zero means do not run discovery automatically|
 


### PR DESCRIPTION
closes #597

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
