### PR TITLE
fix: Update link to post-release security advisory.

### DIFF
--- a/docs_src/microservices/application/BuiltIn.md
+++ b/docs_src/microservices/application/BuiltIn.md
@@ -133,7 +133,7 @@ There are two transforms included in the SDK that can be added to your pipeline 
 ### Encryption (Deprecated)
 
 !!! edgey "EdgeX 2.1"
-    This is deprecated in EdgeX 2.1 - it is recommended to use the new `AESProtection` transform.  Please see [this security advisory](#TODO) for more detail.
+    This is deprecated in EdgeX 2.1 - it is recommended to use the new `AESProtection` transform.  Please see [this security advisory](https://github.com/edgexfoundry/app-functions-sdk-go/security/advisories/GHSA-6c7m-qwxj-mvhp) for more detail.
 
 
 | Factory Method                                               | Description                                                  |


### PR DESCRIPTION
Cherry-pick https://github.com/edgexfoundry/edgex-docs/commit/90c88562df12ae5405ad162d713904bd6b63ad63 into main.
