### PR TITLE
fix(microservices): device-virtual no longer using ql

### DIFF
--- a/docs_src/microservices/device/virtual/Ch-VirtualDevice.md
+++ b/docs_src/microservices/device/virtual/Ch-VirtualDevice.md
@@ -17,8 +17,6 @@ The virtual device service, built in Go and based on the device service Go SDK, 
 - Float32, Float64, Float32Array, Float64Array
 - Binary
 
-The virtual device services leverages [ql(an embedded SQL database engine)](https://godoc.org/github.com/cznic/ql) to simulate virtual resources.
-
 By default, the virtual device service is included and configured to run with all EdgeX Docker Compose files.  This allows users to have a complete EdgeX system up and running - with simulated data from the virtual device service - in minutes.
 
 ## Using the Virtual Device Service


### PR DESCRIPTION
The PR for device-virtual-go issue #260 removes "ql" 
from the service. Remove mention in docs.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
(it seemed safe)