### PR TITLE
fix: stay on page after version switch

### DIFF
--- a/docs_src/assets/javascripts/version-select.js
+++ b/docs_src/assets/javascripts/version-select.js
@@ -57,7 +57,8 @@ window.addEventListener("DOMContentLoaded", function () {
       if (this.value === '1.1') {
         window.location.href = "https://fuji-docs.edgexfoundry.org"
       } else {
-        window.location.href = "/" + this.value;
+        // replace version in the beginning of path with selected version
+        window.location.pathname = window.location.pathname.replace(/^\/(\d.\d)\//, `/${this.value}/`);
       }
     });
 


### PR DESCRIPTION
Related to #678

I believe this fixes the version switch only for version 2.2, when switching to any other version, but not vice versa.

Additional PRs would have to backport this fix into [gh-pages](https://github.com/edgexfoundry/edgex-docs/tree/gh-pages). I guess the CI populates `2.2, 2.1, ...` directories of gh-pages from `main, jakarta, ...` branches? 

To validate that it works, I've tested it locally by switching to gh-pages branch and adding this fix in 2.1 and 2.2 directories. I've then served the files with a python http server:
```
python3 -m http.server
```
See the video below; note the swagger URL version change in the inspection area.


Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)

https://user-images.githubusercontent.com/11150423/151173502-768322c2-3204-4d3c-9413-ec5222a82c68.mp4
