### PR TITLE
fix: stay on page after version switch (ireland)

### DIFF
--- a/docs_src/assets/javascripts/version-select.js
+++ b/docs_src/assets/javascripts/version-select.js
@@ -57,7 +57,8 @@ window.addEventListener("DOMContentLoaded", function () {
       if (this.value === '1.1') {
         window.location.href = "https://fuji-docs.edgexfoundry.org"
       } else {
-        window.location.href = "/" + this.value;
+        // replace version in the beginning of path with selected version
+        window.location.pathname = window.location.pathname.replace(/^\/(\d.\d)\//, `/${this.value}/`);
       }
     });
 

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,0 @@
-[
-    {"version": "1.1", "title": "1.1-Fuji", "aliases": []},
-    {"version": "1.2", "title": "1.2-Geneva", "aliases": []},
-    {"version": "1.3", "title": "1.3-Hanoi", "aliases": []},
-    {"version": "2.0", "title": "2.0-Ireland", "aliases": []}
-]


### PR DESCRIPTION
Same as #679 but for Ireland.

Related to #678

This fixes the version switch from version 2.0 to others, but not vice versa.

It also removes the obsolete versions list from this branch; see #680

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
