### PR TITLE
fix(ref): make link colors consistent

### DIFF
--- a/docs_src/assets/stylesheets/branding.css
+++ b/docs_src/assets/stylesheets/branding.css
@@ -9,17 +9,21 @@
     --md-default-bg-color--lighter:      hsla(0, 0%, 100%, 0.3);
     --md-default-bg-color--lightest:     hsla(0, 0%, 100%, 0.12);
   
-    --md-primary-fg-color:               hsla(282, 65%, 19%, 1);
-    --md-primary-fg-color--light:        hsla(282, 65%, 19%, 1);
-    --md-primary-fg-color--dark:         hsla(282, 65%, 19%, 1);
+    --md-primary-fg-color:               hsla(343, 55%, 37%, 1);
+    --md-primary-fg-color--light:        hsla(343, 55%, 37%, 1);
+    --md-primary-fg-color--dark:         hsla(343, 55%, 37%, 1);
     --md-primary-bg-color:               hsla(0, 0%, 100%, 1);
     --md-primary-bg-color--light:        hsla(0, 0%, 100%, 0.7);
   
-    --md-accent-fg-color:                hsla(343, 55%, 37%, 1);
-    --md-accent-fg-color--transparent:   hsla(343, 55%, 37%, 0.1);
+    --md-accent-fg-color:                hsla(282, 65%, 19%, 1);
+    --md-accent-fg-color--transparent:   hsla(282, 65%, 19%, 0.1);
     --md-accent-bg-color:                hsla(0, 0%, 100%, 1);
     --md-accent-bg-color--light:         hsla(0, 0%, 100%, 0.7);
   
     --md-code-bg-color:                  hsla(0, 0%, 92.5%, 0.5);
     --md-code-fg-color:                  hsla(200, 18%, 26%, 1);
+  }
+
+  .md-header, .md-tabs {
+    background-color: var(--md-accent-fg-color);
   }

--- a/docs_src/assets/stylesheets/links.css
+++ b/docs_src/assets/stylesheets/links.css
@@ -1,4 +1,0 @@
-.md-content {
-    --md-primary-fg-color: #fd5555;
-    --md-accent-fg-color: #a700d1;
-}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -172,6 +172,5 @@ extra_css:
 - assets\stylesheets\branding.css
 - assets\stylesheets\edgey.css
 - assets\stylesheets\newexample.css
-- assets\stylesheets\links.css
 extra_javascript:
 - assets\javascripts\version-select.js


### PR DESCRIPTION
In response to #655, PR #691 changed the link colors to brighter shades of purple and red. That change made the links in body inconsistent with links in the sidebar and ToC.

This PR tries to make the links readable and at the same time stay consistent with other links (sidebar, toc) and the color family. The selected link colors are from the EdgeX color family, identical to the red and purple of the logo, as intended originally. I only swapped the primary and accent colors. I also had to override the header color to be same as the accent (now purple) instead of primary (now red).

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
