### PR TITLE
fix: point to correct link for kubernetes example

### DIFF
--- a/docs_src/examples/index.md
+++ b/docs_src/examples/index.md
@@ -10,7 +10,7 @@ The tabs below provide a listing (may be partial based on latest updates) for re
 === "Deployment"
     |Example|Location|
     |---|---|
-    |Kubernetes|[Github - examples, deployment](https://github.com/edgexfoundry/edgex-examples/tree/main/deployment/kubernetes)|
+    |Kubernetes|[Github - examples, deployment](https://github.com/edgexfoundry/edgex-examples/tree/main/deployment/helm)|
     |Raspberry Pi 4|[Github - examples, raspberry-pi-4](https://github.com/edgexfoundry/edgex-examples/tree/main/deployment/raspberry-pi-4)|
     |Cloud deployments|[Github - examples, cloud deployment templates](https://github.com/edgexfoundry/edgex-examples/tree/main/deployment/templates)|
 


### PR DESCRIPTION
point to `deployment/helm` instead of `deployment/kubernetes`

addresses and closes #720 for `ireland` branch

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
