### PR TITLE
ci: automated Swagger API version changes: 2.2.0 --> 2.3.0

### DIFF
--- a/docs_src/api/applications/Ch-APIAppFunctionsSDK.md
+++ b/docs_src/api/applications/Ch-APIAppFunctionsSDK.md
@@ -4,7 +4,7 @@ The App Functions SDK is provided to help build Application Services by assembli
 
 The App Functions SDK provides a RESTful API that all Application Services inherit from the SDK.
 
-[Application Service SDK V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/app-functions-sdk/2.2.0)
+[Application Service SDK V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/app-functions-sdk/2.3.0)
 
 !!! edgey "EdgeX 2.0"
     For EdgeX 2.0 the REST API provided by the App Functions SDK has changed to use DTOs (Data Transfer Objects) for all responses and for POST requests. One exception is the `/api/v2/trigger` endpoint that is enabled when the Trigger is configured to be `http`. This endpoint accepts any data POSTed to it.

--- a/docs_src/api/core/Ch-APICoreCommand.md
+++ b/docs_src/api/core/Ch-APICoreCommand.md
@@ -17,7 +17,7 @@ into two groups for each device:
     setting the speed in RPMs of a motor, or setting the brightness of a
     dimmer light.
 
-[Core Command V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-command/2.2.0)
+[Core Command V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-command/2.3.0)
 
 !!! edgey "EdgeX 2.0"
     For EdgeX 2.0 the REST API provided by the Core Command has changed to use DTOs (Data Transfer Objects) for all responses and for all PUT requests. All query APIs (GET) which return multiple objects, such as /all, provide `offset` and `limit` query parameters.

--- a/docs_src/api/core/Ch-APICoreData.md
+++ b/docs_src/api/core/Ch-APICoreData.md
@@ -2,7 +2,7 @@
 
 EdgeX Foundry Core Data microservice includes the Events/Readings database collected from devices /sensors and APIs to expose this database to other services. Its APIs to provide access to Add, Query and Delete Events/Readings. See [Core Data](../../microservices/core/data/Ch-CoreData.md) for more details about this service.
 
-[Core Data V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.2.0)
+[Core Data V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.3.0)
 
 !!! edgey "EdgeX 2.0"
     For EdgeX 2.0 the REST API provided by the Core Data has changed to use DTOs (Data Transfer Objects) for all responses and for all POST requests. All query APIs (GET) which return multiple objects, such as /all, provide `offset` and `limit` query parameters.

--- a/docs_src/api/core/Ch-APICoreMetadata.md
+++ b/docs_src/api/core/Ch-APICoreMetadata.md
@@ -5,7 +5,7 @@ and APIs to expose this database to other services. In particular, the
 device provisioning service deposits and manages device metadata through
 this service's API. See [Core Metadata](../../microservices/core/metadata/Ch-Metadata.md) for more details about this service.
 
-[Core Metadata V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.2.0)
+[Core Metadata V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.3.0)
 
 !!! edgey "EdgeX 2.0"
     For EdgeX 2.0 the REST API provided by the Core Metadata has changed to use DTOs (Data Transfer Objects) for all responses and for all POST/PUT/PATCH requests.  All query APIs (GET) which return multiple objects, such as /all, provide `offset` and `limit` query parameters.

--- a/docs_src/api/devices/Ch-APIDeviceSDK.md
+++ b/docs_src/api/devices/Ch-APIDeviceSDK.md
@@ -4,7 +4,7 @@ The EdgeX Foundry Device Service Software Development Kit (SDK) takes the Develo
 
 The Device Service SDK provides a RESTful API that all Device Services inherit from the SDK.
 
-[Device SDK V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/device-sdk/2.2.0)
+[Device SDK V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/device-sdk/2.3.0)
 
 !!! edgey "EdgeX 2.0"
     For EdgeX 2.0 the REST API provided by the Device Service SDK has changed to use DTOs (Data Transfer Objects) for all responses and for all POST/PUT requests. 

--- a/docs_src/api/management/Ch-APISystemManagement.md
+++ b/docs_src/api/management/Ch-APISystemManagement.md
@@ -5,7 +5,7 @@
 
 The EdgeX System Management Agent (SMA) microservice exposes the EdgeX management service API to 3rd party systems. In other words, the Agent serves as a proxy for system management service API calls into each micro service. See [System Management Agent](../../../microservices/system-management/Ch_SystemManagement/) for more details about this service.
 
-[System Management V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/system-agent/2.2.0)
+[System Management V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/system-agent/2.3.0)
 
 !!! edgey "EdgeX 2.0"
     For EdgeX 2.0 the REST API provided by the System Management Agent has changed to use DTOs (Data Transfer Objects) for all responses and for all POST requests. 

--- a/docs_src/api/support/Ch-APISupportNotifications.md
+++ b/docs_src/api/support/Ch-APISupportNotifications.md
@@ -2,7 +2,7 @@
 
 When a person or a system needs to be informed of something discovered on the node by another microservice on the node, EdgeX Foundry's Support Notifications microservice delivers that information. Examples of Alerts and Notifications that other services might need to broadcast include sensor data detected outside of certain parameters, usually detected by a Rules Engine service, or a system or service malfunction usually detected by system management services.  See [Support Notifications](../../microservices/support/notifications/Ch-AlertsNotifications.md) for more details about this service.
 
-[Support Notifications V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.2.0)
+[Support Notifications V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.3.0)
 
 !!! edgey "EdgeX 2.0"
     For EdgeX 2.0 the REST API provided by the Support Notifications has changed to use DTOs (Data Transfer Objects) for all responses and for all POST/PUT/PATCH requests. All query APIs (GET) which return multiple objects, such as /all, provide `offset` and `limit` query parameters.

--- a/docs_src/api/support/Ch-APISupportScheduler.md
+++ b/docs_src/api/support/Ch-APISupportScheduler.md
@@ -3,7 +3,7 @@
 EdgeX Foundry's Support Scheduler microservice to schedule actions to occur on specific intervals. See
 [Support Scheduler](../../microservices/support/scheduler/Ch-Scheduler.md) for more details about this service.
 
-[Support Scheduler V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-scheduler/2.2.0)
+[Support Scheduler V2 API Swagger Documentation](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-scheduler/2.3.0)
 
 !!! edgey "EdgeX 2.0"
     For EdgeX 2.0 the REST API provided by the Support Scheduler has changed to use DTOs (Data Transfer Objects) for all responses and for all POST/PUT/PATCH requests. All query APIs (GET) which return multiple objects, such as /all, provide `offset` and `limit` query parameters.


### PR DESCRIPTION
This PR updates the swagger links to the next release version: 2.3.0