### PR TITLE
fix: cleanup default service ports

### DIFF
--- a/docs_src/general/ServicePorts.md
+++ b/docs_src/general/ServicePorts.md
@@ -5,15 +5,19 @@ The following tables (organized by type of service) capture the default service 
     |Services Name|	Port Definition|
     |---|---|
     |core-data|	59880|
-    |ZMQ - to be deprecated in a future release|5563|
     |core-metadata	|59881|
     |core-command	|59882|
+    |redis|6379|
+    |consul|8500|
+    |ZMQ - deprecated|5563|
 === "Supporting"
     |Services Name|	Port Definition|
     |---|---|
     |support-notifications	|59860|
     |support-scheduler|	59861|
-=== "Application & Analytics"
+    |rules engine / eKuiper|59720|
+    |system management agent- deprecated|58890|
+=== "Application"
     |Services Name|	Port Definition|
     |---|---|
     |app-sample|59700|
@@ -23,7 +27,6 @@ The following tables (organized by type of service) capture the default service 
     |app-http-export|59704|
     |app-functional-tests|59705|
     |app-rfid-llrp-inventory|59711|
-    |rules engine/eKuiper|59720|
 === "Device"
     |Services Name|	Port Definition|
     |---|---|
@@ -34,7 +37,7 @@ The following tables (organized by type of service) capture the default service 
     |device-camera  |59985|
     |device-rest    |59986|
     |device-coap    |59988|
-    |device-llrp    |59989|
+    |device-rfid-llrp    |59989|
     |device-grove   |59992|
     |device-snmp	|59993|
     |device-gpio    |59994|
@@ -43,16 +46,12 @@ The following tables (organized by type of service) capture the default service 
     |---|---|
     |kong-db|5432|
     |vault	|8200|
-    |kong	|8000|
-    |           |8100|
-    |           |8443|
+    |kong	|8000, 8100, 8443|
     |security-spire-server          |59840|
     |security-spiffe-token-provider |59841|
 === "Miscellaneous"
     |Services Name|	Port Definition|
     |---|---|
+    |ui|4000|
     |Modbus simulator|1502|
     |MQTT broker| 1883|
-    |redis|6379|
-    |consul	|8500|
-    |system	management|58890|

--- a/docs_src/general/ServicePorts.md
+++ b/docs_src/general/ServicePorts.md
@@ -4,7 +4,7 @@ The following tables (organized by type of service) capture the default service 
 === "Core"
     |Services Name|	Port Definition|
     |---|---|
-    |core-data|	59880, 5563 (ZMQ; deprecated)|
+    |core-data|	59880<br>5563 (deprecated ZMQ port)|
     |core-metadata	|59881|
     |core-command	|59882|
     |redis|6379|

--- a/docs_src/general/ServicePorts.md
+++ b/docs_src/general/ServicePorts.md
@@ -4,12 +4,11 @@ The following tables (organized by type of service) capture the default service 
 === "Core"
     |Services Name|	Port Definition|
     |---|---|
-    |core-data|	59880|
+    |core-data|	59880, 5563 (ZMQ; deprecated)|
     |core-metadata	|59881|
     |core-command	|59882|
     |redis|6379|
     |consul|8500|
-    |ZMQ - deprecated|5563|
 === "Supporting"
     |Services Name|	Port Definition|
     |---|---|

--- a/docs_src/general/ServicePorts.md
+++ b/docs_src/general/ServicePorts.md
@@ -15,7 +15,7 @@ The following tables (organized by type of service) capture the default service 
     |support-notifications	|59860|
     |support-scheduler|	59861|
     |rules engine / eKuiper|59720|
-    |system management agent- deprecated|58890|
+    |system management agent (deprecated)|58890|
 === "Application"
     |Services Name|	Port Definition|
     |---|---|


### PR DESCRIPTION
- Moved services to the right category, according to the architecture
  - redis and consul to core
  - rules engine to support
  - SMA to support
- Corrected the device-rfid-llrp name
- Added port 4000 for the UI
- Squashed Kong ports into 1 row

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
