### PR TITLE
fix: re-organize the description of supported architectures

### DIFF
--- a/docs_src/general/PlatformRequirements.md
+++ b/docs_src/general/PlatformRequirements.md
@@ -15,11 +15,14 @@ EdgeX Foundry is an operating system (OS)-agnostic and hardware (HW)-agnostic Io
 === "Operating Systems"
     EdgeX Foundry has been run successfully on many systems, including, but not limited to the following systems
 
-    * Windows (ver 7 - 10)
-    * Ubuntu Desktop (ver 14-20)
-    * Ubuntu Server (ver 14-20)
-    * Ubuntu Core (ver 16-18)
-    * Mac OS X 10
+    * Windows 7 and higher
+    * Ubuntu Desktop/Server 14 and higher
+    * Ubuntu Core 16 and higher
+    * Mac OS X
 
 !!! Info
-    EdgeX is agnostic with regards to hardware (x86 and ARM), but only release artifacts for x86 and ARM 64 systems.  EdgeX has been successfully run on ARM 32 platforms but has required users to build their own executable from source.  EdgeX does not officially support ARM 32.
+    EdgeX Foundry runs on various distributions and / or versions of Linux, Unix, MacOS, Windows, etc. However, the community only supports the platform on `amd64` (x86-64) and `arm64` architectures.
+
+    EdgeX Foundry releases pre-built artifacts as Docker images and Snaps. Please refer to [Getting Started](../../getting-started) for details.
+    
+    EdgeX can run on `armhf` architecture but that requires users to build their own executables from source. EdgeX does not officially support `armhf`.

--- a/docs_src/getting-started/Ch-GettingStartedDevelopers.md
+++ b/docs_src/getting-started/Ch-GettingStartedDevelopers.md
@@ -18,7 +18,7 @@ or changing the existing code base.
 ### Hardware
 
 EdgeX Foundry is an operating system (OS) and hardware (HW)-agnostic edge software platform. 
-See the reference page for [platform requirements](./quick-start/index.md#reference-platform-requirements). These provide guidance on a minimal platform to run the EdgeX platform.  However, as a developer, you may find that additional memory, disk space, and improved CPU are essential to building and debugging.
+See the reference page for [platform requirements](../../general/PlatformRequirements). These provide guidance on a minimal platform to run the EdgeX platform.  However, as a developer, you may find that additional memory, disk space, and improved CPU are essential to building and debugging.
 
 ### Software
 

--- a/docs_src/getting-started/index.md
+++ b/docs_src/getting-started/index.md
@@ -1,12 +1,6 @@
 # Getting Started
 
-!!! Attention
-
-    ## Supported Architectures
-
-    EdgeX Foundry is a hardware and operating system agnostic IoT / edge platform.  It is was built to run on Intel and ARM hardware.  It runs on various distributions and / or versions of Linux, Unix, MacOS, Windows, etc.
-
-    However, the EdgeX Foundry community only supports the platform on Intel (x86, x86_64) and ARM64 hardware.  Adopters may build EdgeX for ARM32, but the community does not support or provide pre-built artifacts such as Docker containers, snaps, etc. for ARM32.  Building EdgeX for ARM32 will typically require some modifications to the build process.  Some services may not compile on ARM32 and/or require removal of components such as ZMQ that are not available or compile on ARM32.
+EdgeX Foundry is operating system and architecture agnostic. The community releases artifacts for common architectures. However, it is possible to build the components for other platforms. See the [platform requirements](../general/PlatformRequirements) reference page for details.
 
 To get started you need to get EdgeX Foundry either as a User or as a Developer/Contributor.
 


### PR DESCRIPTION
PR https://github.com/edgexfoundry/edgex-docs/pull/744 added the description of supported architectures. The text has some overlapping information with the platform requirement page. I've moved the information to the platforms requirements page and linked to it. Also fixed another hyperlink to that page.

Other resolved issues:
- It claimed that ZMQ doesn't compile on arm32, which isn't accurate. Compiling ZMQ for arm32 is possible; cross-compiling it is difficult.
- A blanket statement that artifacts are released only for amd64 and arm64 is limiting. In some cases, we may want to release some services for other architectures. For example, the [device-gpio snap](https://snapcraft.io/edgex-device-gpio) is built also for armhf to allow installation on a wider range of devices.

Related to #702

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
