### PR TITLE
fix(example): update the configuration of the "Adding a MQTT device" example

### DIFF
--- a/docs_src/examples/Ch-ExamplesAddingMQTTDevice.md
+++ b/docs_src/examples/Ch-ExamplesAddingMQTTDevice.md
@@ -149,7 +149,9 @@ Open the `edgex-compose/compose-builder/docker-compose.yml` file and then add vo
       DEVICE_PROFILESDIR: /custom-config/profiles
       ...
     volumes:
-    - /path/to/custom-config:/custom-config
+    - type: bind
+      src: /path/to/custom-config
+      target: /custom-config
     ...
 ```
 


### PR DESCRIPTION
The previous config will incur read commands failed when executing the following command:

`curl http://localhost:59882/api/v2/device/all | json_pp`

This commit fixes the docker-compose format in the "Mount the custom-config" section.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
