### PR TITLE
fix: update google analytics config per latest documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,8 +12,6 @@ theme:
   name: 'material'
   logo: 'assets/logo_edgex_white.png'
   favicon: 'assets/logo_edgex.png'
-  analytics:
-    gtag: 'G-38531ZZHBN'
   features:
     - navigation.tabs  # changed with version 6 of mkdocs-materials
 nav:
@@ -176,6 +174,9 @@ extra:
       link: 'https://twitter.com/edgexfoundry'
     - icon: 'fontawesome/brands/linkedin'
       link: 'https://www.linkedin.com/company/edgexfoundry'
+  analytics:
+    provider: google
+    property: G-38531ZZHBN
 extra_css:
 - assets\stylesheets\version-select.css
 - assets\stylesheets\branding.css


### PR DESCRIPTION
Update Google Analytics configuration based on the latest found mkdocs documentation here: https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#configuration

I verified that the Google Analytics snippet is now in the generated HTML

```html
...
<script>function gtag(){dataLayer.push(arguments)}window.dataLayer=window.dataLayer||[],gtag("js",new Date),gtag("config","G-38531ZZHBN"),document.addEventListener("DOMContentLoaded",function(){document.forms.search&&document.forms.search.query.addEventListener("blur",function(){this.value&&gtag("event","search",{search_term:this.value})}),"undefined"!=typeof location$&&location$.subscribe(function(e){gtag("config","G-38531ZZHBN",{page_path:e.pathname})})})</script>
<script async src="https://www.googletagmanager.com/gtag/js?id=G-38531ZZHBN"></script>
...
```

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
