### PR TITLE
ci: only enable HTML proofer for Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,9 @@ pipeline {
     triggers {
         issueCommentTrigger('.*^recheck$.*')
     }
+    environment {
+        ENABLED_HTMLPROOFER = true
+    }
     stages {
         stage('Build Docs') {
             agent {

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ build-docs: build-docker
 	docker run --rm \
 		-v $(PWD):/docs \
 		-w /docs \
+		-e ENABLED_HTMLPROOFER \
 		$(MKDOCS_IMAGE) \
 		build
 
@@ -29,5 +30,6 @@ serve: build-docker
 		-p 8001:8000 \
 		-v $(PWD):/docs \
 		-w /docs \
+		-e ENABLED_HTMLPROOFER \
 		$(MKDOCS_IMAGE)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Documentation for developing with EdgeX-Docs
 [![Build Status](https://jenkins.edgexfoundry.org/view/EdgeX%20Foundry%20Project/job/edgexfoundry/job/edgex-docs/job/main/badge/icon)](https://jenkins.edgexfoundry.org/view/EdgeX%20Foundry%20Project/job/edgexfoundry/job/edgex-docs/job/main/) [![GitHub Pull Requests](https://img.shields.io/github/issues-pr-raw/edgexfoundry/edgex-docs)](https://github.com/edgexfoundry/edgex-docs/pulls) [![GitHub Contributors](https://img.shields.io/github/contributors/edgexfoundry/edgex-docs)](https://github.com/edgexfoundry/edgex-docs/contributors) [![GitHub Committers](https://img.shields.io/badge/team-committers-green)](https://github.com/orgs/edgexfoundry/teams/edgex-docs-committers/members) [![GitHub Commit Activity](https://img.shields.io/github/commit-activity/m/edgexfoundry/edgex-docs)](https://github.com/edgexfoundry/edgex-docs/commits)
 
-## Local Development (docker) (recommended):
+## Local Development (docker) (recommended)
 
 The most common use case for local development of edgex-docs will be to verify changes to the HTML. To facilitate docs verification you can run the following command:
 
@@ -41,13 +41,21 @@ In order to render and preview the site locally (without docker) you will need a
 
 To check that all the links in the documentation set are valid:
 
-1. Install the htmlproofer plugin:
+1. Install the htmlproofer plugin (native only):
 
-    ``` shell
-        pip install mkdocs-htmlproofer-plugin
-    ```
+	> Note: if using the docker method, this is already installed in the image
 
-2. Uncomment the htmlproofer plugin in mkdocs.yml
+	```shell
+	pip install mkdocs-htmlproofer-plugin
+	```
+
+2. Export the `ENABLED_HTMLPROOFER` environment variable.
+
+	> Note: This adds about 5 minutes each time a change is made, so it is recommended to do once all changes are ready.
+
+	```shell
+	export ENABLED_HTMLPROOFER=true
+	```
 
 3. Run `make build` or `make serve`. Broken links will be listed at the end of the build process.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,6 +187,7 @@ extra_javascript:
 plugins:
   - search
   - htmlproofer:
+      enabled: !ENV [ENABLED_HTMLPROOFER, False]
       raise_error: True
       raise_error_excludes:
         404: ['https://support.google.com/accounts/answer/185833?hl=en', 


### PR DESCRIPTION
Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
