### PR TITLE
revert: hanoi/geneva version override by CI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Redirecting</title>
-  <script>
-    window.location.replace("1.3");
-  </script>
+    <meta http-equiv="refresh" content="0; url=/latest">
 </head>
 <body>
+  Redirecting to latest...
 </body>
 </html>

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,9 @@
 [
-    {"version": "1.1", "title": "1.1-Fuji", "aliases": []},
-    {"version": "1.2", "title": "1.2-Geneva", "aliases": []},
-    {"version": "1.3", "title": "1.3-Hanoi", "aliases": []}
+  { "version": "1.1", "title": "1.1-Fuji", "aliases": [] },
+  { "version": "1.2", "title": "1.2-Geneva", "aliases": [] },
+  { "version": "1.3", "title": "1.3-Hanoi", "aliases": [] },
+  { "version": "2.0", "title": "2.0-Ireland", "aliases": [] },
+  { "version": "2.1", "title": "2.1-Jakarta", "aliases": [] },
+  { "version": "2.2", "title": "2.2-Kamakura", "aliases": ["latest"] },
+  { "version": "2.3", "title": "2.3-Levski", "aliases": [] }
 ]


### PR DESCRIPTION
The following PRs included the old version and index files which overrode the production copies: #819, #820

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
