### PR TITLE
feat: Referencing doc pages with latest alias

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<!--
+    This is a special page used by Github Pages when a requested page is not found.
+    The script is misused for redirecting requests that use the "latest" alias to
+    the latest version of a page.
+-->
+<html>
+<head>
+    <title>404 Not Found</title>
+    <script>
+        // redirectToLatest redirects the user agent to the latest version of a 
+        // page by rewriting the path.
+        //
+        // Examples:
+        //   https://docs.edgexfoundry.org/latest is redirected to:
+        //   https://docs.edgexfoundry.org/2.2
+        //
+        //   https://docs.edgexfoundry.org/latest/getting-started/ is redirected to:
+        //   https://docs.edgexfoundry.org/2.2/getting-started/
+        function redirectToLatest()
+        {
+            let req = new XMLHttpRequest();
+            req.open("GET", "/versions.json", false);
+            req.send();
+            if(req.status === 200){
+                let versions = JSON.parse(req.responseText);
+
+                // find the version by alias
+                let res = versions.find(it => {
+                    return it["aliases"].find(alias => {
+                        return alias == "latest";
+                    });
+                });
+
+                if (res && res.version) {
+                    // rewrite the path and replace the alias with version
+                    let pathParts = window.location.pathname.split("/");
+                    pathParts[1] = res.version;
+                    window.location.pathname = pathParts.join("/");
+                } else {
+                    alert("Unable to find version with 'latest' alias.");
+                    return;
+                }
+            } else {
+                alert("Error querying the versions file.");
+                return;
+            }
+        }
+
+        // When the 'latest' alias is in the path, redirect to the actual page
+        // instead of showing the 404 page.
+        if(window.location.pathname.split("/")[1]=="latest"){
+            redirectToLatest();
+        }
+    </script>
+</head>
+<body>
+    <h1>404 Not Found</h1>
+    <p>
+        The requested page was not found.
+    </p>
+    <p>
+        To visit the latest documentation, please visit
+        <a href="https://docs.edgexfoundry.org">https://docs.edgexfoundry.org</a>.
+    </p>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Redirecting</title>
-  <script>
-    window.location.replace("2.2");
-  </script>
+    <meta http-equiv="refresh" content="0; url=/latest">
 </head>
 <body>
+  Redirecting to latest...
 </body>
 </html>

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -4,6 +4,6 @@
   { "version": "1.3", "title": "1.3-Hanoi", "aliases": [] },
   { "version": "2.0", "title": "2.0-Ireland", "aliases": [] },
   { "version": "2.1", "title": "2.1-Jakarta", "aliases": [] },
-  { "version": "2.2", "title": "2.2-Kamakura", "aliases": [] },
+  { "version": "2.2", "title": "2.2-Kamakura", "aliases": ["latest"] },
   { "version": "2.3", "title": "2.3-Levski", "aliases": [] }
 ]


### PR DESCRIPTION
This is a replica of https://github.com/edgexfoundry/edgex-docs/pull/813 to have the files on the main branch. The original PR added the changes directly to the gh-pages branch some of which were getting overridden by copies in main.

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
