### PR TITLE
fix: Fix broken link to docker compose install

### DIFF
--- a/docs_src/getting-started/Ch-GettingStartedDockerUsers.md
+++ b/docs_src/getting-started/Ch-GettingStartedDockerUsers.md
@@ -18,7 +18,7 @@ educational information. The following short video is also very
 informative <https://www.youtube.com/watch?time_continue=3&v=VhabrYF1nms>
 
 Use Docker Compose to orchestrate the fetch (or pull), install,
-and start the EdgeX micro service containers.  Also use Docker Compose to stop the micro service containers. See: <https://docs.docker.com/compose/> to learn more about Docker Compose and <https://docs.docker.com/compose/install/compose-plugin/>  to install it.
+and start the EdgeX micro service containers.  Also use Docker Compose to stop the micro service containers. See: <https://docs.docker.com/compose/> to learn more about Docker Compose and <https://docs.docker.com/compose/install/linux/>  to install it.
 
 You do not need to be an expert with Docker (or Docker Compose) to get and run EdgeX. This guide provides the steps to get EdgeX running in your environment. Some knowledge of Docker and Docker Compose are nice to have, but not required. Basic Docker and Docker Compose commands provided here enable you to run, update, and diagnose issues within EdgeX.
 


### PR DESCRIPTION
Docker seems to be actively updating their Compose documention, so the previous link
is no longer valid.

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
