### PR TITLE
fix: correct broken links in Kamakura version of docs

### DIFF
--- a/docs_src/examples/index.md
+++ b/docs_src/examples/index.md
@@ -23,10 +23,8 @@ The tabs below provide a listing (may be partial based on latest updates) for re
 === "Security"
     |Example|Location|
     |---|---|
-    |Docker Swarm, remote device service via overlay network|[Github - Docker Swarm](https://github.com/edgexfoundry/edgex-examples/tree/v2.2.0/security/remote_devices/docker-swarm)|
-    |SSH Tunneling, remote device service via SSH tunneling|[Github - SSH Tunneling](https://github.com/edgexfoundry/edgex-examples/tree/v2.2.0/security/remote_devices/ssh-tunneling)|
-
-
+    |Docker Swarm, remote device service via overlay network|[Github - Docker Swarm](https://github.com/edgexfoundry/edgex-examples/tree/v2.1.0/security/remote_devices/docker-swarm)|
+    |SSH Tunneling, remote device service via SSH tunneling|[Github - SSH Tunneling](https://github.com/edgexfoundry/edgex-examples/tree/v2.1.0/security/remote_devices/ssh-tunneling)|
 
 !!! Warning
     Not all the examples in the EdgeX Examples repository are available for all EdgeX releases.  Check the documentation for details.

--- a/docs_src/getting-started/Ch-GettingStartedDockerUsers.md
+++ b/docs_src/getting-started/Ch-GettingStartedDockerUsers.md
@@ -18,7 +18,7 @@ educational information. The following short video is also very
 informative <https://www.youtube.com/watch?time_continue=3&v=VhabrYF1nms>
 
 Use Docker Compose to orchestrate the fetch (or pull), install,
-and start the EdgeX micro service containers.  Also use Docker Compose to stop the micro service containers. See: <https://docs.docker.com/compose/> to learn more about Docker Compose and <https://docs.docker.com/compose/install/compose-plugin/> to install it.
+and start the EdgeX micro service containers.  Also use Docker Compose to stop the micro service containers. See: <https://docs.docker.com/compose/> to learn more about Docker Compose.
 
 You do not need to be an expert with Docker (or Docker Compose) to get and run EdgeX. This guide provides the steps to get EdgeX running in your environment. Some knowledge of Docker and Docker Compose are nice to have, but not required. Basic Docker and Docker Compose commands provided here enable you to run, update, and diagnose issues within EdgeX.
 

--- a/docs_src/microservices/support/eKuiper/Ch-eKuiper.md
+++ b/docs_src/microservices/support/eKuiper/Ch-eKuiper.md
@@ -40,9 +40,9 @@ Note: "Configure the data flow" tutorial in the list below is a **new tutorial**
 - [EdgeX eKuiper Rules Engine Tutorial](https://github.com/lf-edge/ekuiper/blob/master/docs/en_US/edgex/edgex_rule_engine_tutorial.md): A 10-minute quick start tutorial, readers can refer to this article to start trying out the rules engine.
 - [Configure the data flow from EdgeX to eKuiper](https://github.com/lf-edge/ekuiper/blob/master/docs/en_US/edgex/edgex_source_tutorial.md):  a demonstrate on how to set up the various data flows from EdgeX to eKuiper.  Learn how to configure the source to adopt any kind of data flow.
 - [Control the device with the EdgeX eKuiper rules engine](https://github.com/lf-edge/ekuiper/blob/master/docs/en_US/edgex/edgex_rule_engine_command.md): This article describes how to use the eKuiper rule engine in EdgeX to control the device based on the analysis results.
-- Read [EdgeX Source](https://github.com/lf-edge/ekuiper/blob/master/docs/en_US/rules/sources/edgex.md) to get more detailed information, and type conversions.
+- Read [EdgeX Source](https://github.com/lf-edge/ekuiper/blob/master/docs/en_US/rules/sources/builtin/edgex.md) to get more detailed information, and type conversions.
 - [How to use the meta function to extract more information sent in the EdgeX message bus?](https://github.com/lf-edge/ekuiper/blob/master/docs/en_US/edgex/edgex_meta.md) When the device service sends data to the bus, some additional information is also sent, such as creation time and id. If you want to use this information in SQL statements, please refer to this article.
-- [EdgeX Message Bus Sink](https://github.com/lf-edge/ekuiper/blob/master/docs/en_US/rules/sinks/edgex.md): The document describes how to use EdgeX message bus sink. If you'd like to have your analysis result consumed by other EdgeX services, you can send analysis data with EdgeX data format through this sink, and other EdgeX services can subscribe new message bus exposed by eKuiper sink.
+- [EdgeX Message Bus Sink](https://github.com/lf-edge/ekuiper/blob/master/docs/en_US/rules/sinks/builtin/edgex.md): The document describes how to use EdgeX message bus sink. If you'd like to have your analysis result consumed by other EdgeX services, you can send analysis data with EdgeX data format through this sink, and other EdgeX services can subscribe new message bus exposed by eKuiper sink.
 
 !!! Info
   The eKuiper tutorials and documentation are available in both [English](https://github.com/lf-edge/ekuiper/tree/master/docs/en_US/edgex) and [Chinese](https://github.com/lf-edge/ekuiper/tree/master/docs/zh_CN/edgex).
@@ -50,4 +50,4 @@ Note: "Configure the data flow" tutorial in the list below is a **new tutorial**
 For more information on the LF Edge eKuiper project, please refer to the following resources.
 
 - [eKuiper Github Code library](https://github.com/lf-edge/ekuiper/)
-- [eKuiper Reference](https://github.com/lf-edge/ekuiper/blob/master/docs/en_US/reference.md)
+- [eKuiper Reference](https://github.com/lf-edge/ekuiper/blob/master/docs/en_US/README.md)


### PR DESCRIPTION
fixes: #778

all of these fixes are already in Levski/main branch

most of these issues are due to changes to source or 3rd party docs post Kamakura release

Signed-off-by: jpwhitemn <jpwhite_mn@yahoo.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
