### PR TITLE
feat: Document new "none" value for EDGEX_CONFIGURATION_PROVIDER

### DIFF
--- a/docs_src/microservices/configuration/CommonEnvironmentVariables.md
+++ b/docs_src/microservices/configuration/CommonEnvironmentVariables.md
@@ -80,6 +80,8 @@ This environment variable overrides the [`-f/--file` command-line option](../Com
 
 This environment variable overrides the [`-cp/--configProvider` command-line option](../CommonCommandLineOptions#config-provider). 
 
+Overriding with a value of `none` disables the use of the Configuration Provider.
+
 !!! note
     All EdgeX service Docker images have this option set to `-cp=consul.http://edgex-core-consul:8500`.
 
@@ -87,6 +89,11 @@ This environment variable overrides the [`-cp/--configProvider` command-line opt
     ```yaml
     environment: 
       EDGEX_CONFIGURATION_PROVIDER: "consul.http://edgex-consul:9500"
+    
+    or
+    
+    environment: 
+      EDGEX_CONFIGURATION_PROVIDER: "none"
     ```
 
 #### EDGEX_PROFILE


### PR DESCRIPTION
Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
