### PR TITLE
fix: Replace broken link for SHH Server in docker

### DIFF
--- a/docs_src/security/Ch-RemoteDeviceServices.md
+++ b/docs_src/security/Ch-RemoteDeviceServices.md
@@ -188,7 +188,7 @@ In this use case, however,
 we are not using `sshd` for remote administration,
 but instead to set up a network tunnel.
 
-For an example of how to run a SSH server in Docker, checkout <https://docs.docker.com/engine/examples/running_ssh_service/> for detailed instructions.
+For an example of how to run a SSH server in Docker, checkout the [SPIFFE and SHH example](https://github.com/edgexfoundry/edgex-examples/tree/main/security/remote_devices/spiffe_and_ssh) for detailed instructions.
 
 The `generate-keys.sh` helper script generates an RSA keypair,
 and copies the `authorized_keys` file into the


### PR DESCRIPTION
Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
