### PR TITLE
fix: pin mkdocs material to avoid upstream breaking changes

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -17,7 +17,7 @@
 
 FROM python:3-slim
 
-RUN pip install mkdocs "mkdocs-material>=8.2" "mkdocs-htmlproofer-plugin>=0.8" "mkdocs-macros-plugin>=0.5"
+RUN pip install mkdocs "mkdocs-material==8.5.8" "mkdocs-htmlproofer-plugin>=0.8" "mkdocs-macros-plugin>=0.5"
 
 EXPOSE 8000
 


### PR DESCRIPTION
Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
