### PR TITLE
feat!: Remove deprecated kuiper and ASC from edgexfoundry snap

### DIFF
--- a/docs_src/getting-started/Ch-GettingStartedSnapUsers.md
+++ b/docs_src/getting-started/Ch-GettingStartedSnapUsers.md
@@ -304,9 +304,6 @@ The following services are disabled by default:
 - support-notifications
 - support-scheduler
 - sys-mgmt-agent - *deprecated EdgeX component*
-- kuiper (Rules Engine / eKuiper) - *deprecated; use the standalone [EdgeX eKuiper snap](#edgex-ekuiper)*
-- app-service-configurable (used to filter events for kuiper) - *deprecated; use the standalone [App Service Configurable snap](#app-service-configurable)*
-
 
 The disabled services can be manually enabled and started; see [managing services].
 
@@ -516,9 +513,6 @@ For usage instructions, refer to [Command Line Interface (CLI)](../tools/Ch-Comm
 
 For the documentation of the standalone EdgeX eKuiper snap, visit the [README](https://github.com/canonical/edgex-ekuiper-snap).
 
-!!! note
-    The standalone EdgeX eKuiper snap documented here should not be confused with the deprecated `edgexfoundry.kuiper` and `edgexfoundry.kuiper-cli` apps built into the platform. The standalone snap can provide similar functionality.
-
 <!-- sorted alphabetically -->
 ### App Service Configurable
 | [Installation][edgex-app-service-configurable] | [Configuration] | [Managing Services] | [Debugging] | [Source](https://github.com/edgexfoundry/app-service-configurable/tree/main/snap) |
@@ -565,9 +559,6 @@ For example, to set `mqtt-export` profile using the snap CLI:
 ```bash
 sudo snap set edgex-app-service-configurable profile=mqtt-export
 ```
-
-!!! note
-    The standalone App Service Configurable snap documented above should not be confused with the deprecated `edgexfoundry.app-service-configurable`, built into the platform snap. The standalone snap can serve the same functionality of filtering events for eKuiper by using the rules-engine profile.
 
 ### App RFID LLRP Inventory
 | [Installation][edgex-app-rfid-llrp-inventory] | [Configuration] | [Managing Services] | [Debugging] | [Source](https://github.com/edgexfoundry/app-rfid-llrp-inventory/tree/main/snap) |


### PR DESCRIPTION
This PR updates the documentation as two deprecated apps kuiper and ASC will be removed from edgexfoundry snap since version 3.0. They are available as standalone snaps: [edgex-app-service-configurable snap](https://snapcraft.io/edgex-app-service-configurable) and [edegx-ekuiper snap](https://snapcraft.io/edgex-ekuiper).

Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
