### PR TITLE
docs: Update docs to use true/false for ds-pushevent and ds-returnevent in 3.0

### DIFF
--- a/docs_src/design/adr/0023-North-South-Messaging.md
+++ b/docs_src/design/adr/0023-North-South-Messaging.md
@@ -127,8 +127,8 @@ Command requests in HTTP may also contain ds-pushevent and ds-returnevent query 
     "Correlation-ID": "14a42ea6-c394-41c3-8bcd-a29b9f5e6835",
     "API":"V2",
     "queryParams": {
-        "ds-pushevent":"yes",
-        "ds-returnevent":"yes",
+        "ds-pushevent":"true",
+        "ds-returnevent":"true",
      }
      ...
 }
@@ -149,8 +149,8 @@ In the example GET and PUT messages below, note the `envelope` wraps or encases 
     "apiVersion": "v2",
     "requestId": "e6e8a2f4-eb14-4649-9e2b-175247911369",
     "queryParams": {
-        "ds-pushevent":"yes",
-        "ds-returnevent":"yes",
+        "ds-pushevent":"true",
+        "ds-returnevent":"true",
      }
 }
 

--- a/docs_src/design/adr/device-service/0011-DeviceService-Rest-API.md
+++ b/docs_src/design/adr/device-service/0011-DeviceService-Rest-API.md
@@ -126,10 +126,14 @@ The fields of an Event are as follows:
 
 Calls to the device endpoints may include a Query String in the URL. This may be used to pass parameters relating to the request to the device service. Individual device services may define their own parameters to control specific behaviors. Parameters beginning with the prefix `ds-` are reserved to the Device SDKs and the following parameters are defined for GET requests:
 
-| Parameter | Valid Values | Default | Meaning
-| --- | --- | --- | ---
-| *ds-pushevent* | "yes" or "no" | "no" | If set to yes, a successful `GET` will result in an event being pushed to the EdgeX system
-| *ds-returnevent* | "yes" or "no" | "yes" | If set to no, there will be no Event returned in the http response
+| Parameter | Valid Values      | Default | Meaning
+| --- |-------------------|---------| ---
+| *ds-pushevent* | "true" or "false" | "false" | If set to true, a successful `GET` will result in an event being pushed to the EdgeX system
+| *ds-returnevent* | "true" or "false" | "true"  | If set to false, there will be no Event returned in the http response
+
+!!! edgey "EdgeX 3.0"
+    The valid values of **ds-pushevent** and **ds-returnevent** is changed to `true/false` instead of `yes/no` in EdgeX 3.0.
+
 
 #### Device States
 

--- a/docs_src/microservices/core/command/Ch-Command.md
+++ b/docs_src/microservices/core/command/Ch-Command.md
@@ -380,8 +380,8 @@ Example of making get command request via messaging:
   "CorrelationID": "14a42ea6-c394-41c3-8bcd-a29b9f5e6835",
   "RequestId": "e6e8a2f4-eb14-4649-9e2b-175247911369",
   "QueryParams": {
-    "ds-pushevent": "no",
-    "ds-returnevent": "yes"
+    "ds-pushevent": "false",
+    "ds-returnevent": "true"
   }
 }
 ```


### PR DESCRIPTION

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
