### PR TITLE
fix: remove references to deprecated code for EncryptWithAES

### DIFF
--- a/docs_src/microservices/application/AppServiceConfigurable.md
+++ b/docs_src/microservices/application/AppServiceConfigurable.md
@@ -425,35 +425,19 @@ Please refer to the function's detailed documentation by clicking the function n
 ### [Encrypt](../BuiltIn/#dataprotection)
 **Parameters**
 
-- `Algorithm` - AES (deprecated) or AES256
-- `Key` -  (optional, deprecated) Encryption key used for the encryption. Required if not using Secret Store for the encryption key data
-- `InitVector` - (deprecated) Initialization vector used for the encryption.
-- `SecretPath` - (required for AES256) Path in the `Secret Store` where the encryption key is located. Required if `Key` not specified.
-- `SecretName` - (required for AES256) Name of the secret for the encryption key in the `Secret Store`.  Required if `Key` not specified.
+- `Algorithm` - AES256
+- `SecretPath` - (required for AES256) Path in the `Secret Store` where the encryption key is located.
+- `SecretName` - (required for AES256) Name of the secret for the encryption key in the `Secret Store`.
 
 !!! example
-    ```toml
-        # Encrypt with key specified in configuration
-        [Writable.Pipeline.Functions.Encrypt]
-          [Writable.Pipeline.Functions.Encrypt.Parameters]
-          Algorithm = "aes" 
-          Key = "aquqweoruqwpeoruqwpoeruqwpoierupqoweiurpoqwiuerpqowieurqpowieurpoqiweuroipwqure"
-          InitVector = "123456789012345678901234567890"
-    ```
     ```toml
         # Encrypt with key pulled from Secret Store
         [Writable.Pipeline.Functions.Encrypt]
           [Writable.Pipeline.Functions.Encrypt.Parameters]
-          Algorithm = "aes"
-          InitVector = "123456789012345678901234567890"
+          Algorithm = "aes256"
           SecretPath = "aes"
           SecretName = "key"
     ```
-
-
-
-!!! edgey "EdgeX 2.0"
-    For EdgeX 2.0 the `EncryptWithAES` configurable pipeline function have been replaced by the `Encrypt` configurable pipeline function with additional `Algorithm ` parameter. In addition the ability to pull the encryption key from the `Secret Store` has been added.
 
 ### [FilterByDeviceName](../BuiltIn/#by-device-name)
 

--- a/docs_src/microservices/application/BuiltIn.md
+++ b/docs_src/microservices/application/BuiltIn.md
@@ -164,32 +164,6 @@ This enables the ability to wrap data into an Event/Reading
 
 There are two transforms included in the SDK that can be added to your pipeline for data protection. 
 
-### Encryption (Deprecated)
-
-!!! edgey "EdgeX 2.1"
-    This is deprecated in EdgeX 2.1 - it is recommended to use the new `AESProtection` transform.  Please see [this security advisory](https://github.com/edgexfoundry/app-functions-sdk-go/security/advisories/GHSA-6c7m-qwxj-mvhp) for more detail.
-
-
-| Factory Method                                                                              | Description                                                                                                                                                                                                                                                                                                                                                                                                                   |
-|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| NewEncryption(key string, initializationVector string)                                      | This function returns a `Encryption` instance initialized with the passed in `key` and `initialization vector`. This `Encryption` instance is used to access the following encryption function that will use the specified `key` and `initialization vector`.                                                                                                                                                                 |
-| NewEncryptionWithSecrets(secretPath string, secretName string, initializationVector string) | This function returns a `Encryption` instance initialized with the passed in `secret path`, `Secret name` and `initialization vector`. This `Encryption` instance is used to access the following encryption function that will use the encryption key from the Secret Store and the passed in `initialization vector`. It uses the passed in`secret path` and `secret name` to pull the encryption key from the Secret Store |
-
-!!! edgey "EdgeX 2.0"
-    New for EdgeX 2.0 is the ability to pull the encryption key from the Secret Store. The encryption key must be seeded into the Secret Store using the `/api/v2/secret` endpoint on the running instance of the Application Service prior to the Encryption function executing. See [App Functions SDK swagger](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/app-functions-sdk/2.0.0#/default/post_secret) for more details on this endpoint.
-
-`EncryptWithAES` - This pipeline function receives either a `string`, `[]byte`, or `json.Marshaller` type and encrypts it using AES encryption and returns a `[]byte` to the pipeline.
-
-!!! example
-    ```go
-    NewEncryption("key", "initializationVector").EncryptWithAES
-    or
-    NewEncryptionWithSecrets("aes", "aes-key", "initializationVector").EncryptWithAES)
-    ```
-
-!!! note
-    The `algorithm` used used with app-service-configurable configuration to access this transform is `AES` 
-
 ### AESProtection
 
 !!! edgey "Edgex 2.1"


### PR DESCRIPTION
Signed-off-by: Marc-Philippe Fuller <marc-philippe.fuller@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
