### PR TITLE
fix: remove deprecated GetSecret sections for ApplicationService API …

### DIFF
--- a/docs_src/microservices/application/AppFunctionContextAPI.md
+++ b/docs_src/microservices/application/AppFunctionContextAPI.md
@@ -187,15 +187,6 @@ This API will replace placeholders of the form `{context-key-name}` with the val
 
 ## Secrets
 
-### GetSecret - DEPRECATED
-
-`GetSecret(path string, keys ...string)`
-
-This API is used to retrieve secrets from the secret store. `path` specifies the type or location of the secrets to retrieve. If specified, it is appended to the base path from the exclusive secret store configuration. `keys` specifies the list of secrets to be retrieved. If no keys are provided then all the keys associated with the specified path will be returned.
-
-!!! warning
-    GetSecret is deprecated and will be removed in EdgeX 3.0. Use `SecretProvider().GetSerect()`
-
 ### SecretsLastUpdated - DEPRECATED
 `SecretsLastUpdated()`
 

--- a/docs_src/microservices/application/ApplicationServiceAPI.md
+++ b/docs_src/microservices/application/ApplicationServiceAPI.md
@@ -28,7 +28,6 @@ type ApplicationService interface {
 	LoadConfigurableFunctionPipelines() (map[string]FunctionPipeline, error)
 	MakeItRun() error
 	MakeItStop()
-	GetSecret(path string, keys ...string) (map[string]string, error)
 	StoreSecret(path string, secretData map[string]string) error 
     SecretProvider() interfaces.SecretProvider
 	LoggingClient() logger.LoggingClient
@@ -403,27 +402,6 @@ This API  stops the configured trigger so that the functions pipeline no longer 
 ## Secrets APIs
 
 The following `ApplicationService` APIs allow your service retrieve and store secrets from/to the service's SecretStore. See the [Secrets](../AdvancedTopics/#secrets) advanced topic for more details about using secrets.
-
-### GetSecret - DEPRECATED
-
-`GetSecret(path string, keys ...string) (map[string]string, error)`
-
-This API returns the secret data from the secret store (secure or insecure) for the specified path. An error is returned if the path is not found or any of the keys (if specified) are not found. Omit keys if all secret data for the specified path is required.
-
-!!! example "Example - GetSecret"
-
-    ```go
-    secretData, err := service.GetSecret("mqtt")
-    if err != nil {
-       ...
-    }
-    username := secretData["user"]
-    password := secretData["password"]
-    ...
-    ```
-
-!!! warning
-    GetSecret is deprecated and will be removed in EdgeX 3.0. Use `SecretProvider().GetSerect()`
 
 ### StoreSecret  - DEPRECATED
 


### PR DESCRIPTION
…and Context API

Signed-off-by: Marc-Philippe Fuller <marc-philippe.fuller@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
