### PR TITLE
fix: remove deprecated PushToCore references

### DIFF
--- a/docs_src/microservices/application/AppFunctionContextAPI.md
+++ b/docs_src/microservices/application/AppFunctionContextAPI.md
@@ -27,7 +27,6 @@ type AppFunctionContext interface {
     DeviceProfileClient() interfaces.DeviceProfileClient
     DeviceClient() interfaces.DeviceClient
     MetricsManager() bootstrapInterfaces.MetricsManager
-    PushToCore(event dtos.Event) (common.BaseWithIdResponse, error)
     GetDeviceResource(profileName string, resourceName string) (dtos.DeviceResource, error)
     AddValue(key string, value string)
     RemoveValue(key string)
@@ -79,7 +78,7 @@ Returns a `LoggingClient` to leverage logging libraries/service utilized through
 
 `EventClient() interfaces.EventClient`
 
-Returns an `EventClient` to leverage Core Data's `Event` API. See [interface definition](https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/clients/interfaces/event.go) for more details. This client is useful for querying events and is used by the [PushToCore](#pushtocore) convenience API described below. Note if Core Data is not specified in the Clients configuration, this will return nil.
+Returns an `EventClient` to leverage Core Data's `Event` API. See [interface definition](https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/clients/interfaces/event.go) for more details. This client is useful for querying events. Note if Core Data is not specified in the Clients configuration, this will return nil.
 
 ### CommandClient
 
@@ -223,17 +222,6 @@ This API returns the content type of the data that initiated the pipeline execut
 `GetDeviceResource(profileName string, resourceName string) (dtos.DeviceResource, error)`
 
 This API retrieves the DeviceResource for the given profile / resource name. Results are cached to minimize HTTP traffic to core-metadata.
-
-### PushToCore()
-`PushToCore(event dtos.Event)`
-
-This API is used to push data to EdgeX Core Data so that it can be shared with other applications that are subscribed to the message bus that core-data publishes to. This function will return the new EdgeX Event with the ID populated, along with any error encountered.  Note that CorrelationId will not be available.
-
-!!! note
-    If validation is turned on in CoreServices then your deviceName and readingName must exist in the CoreMetadata and be properly registered in EdgeX.
-
-!!! warning
-    Be aware that without a filter in your pipeline, it is possible to create an infinite loop when the Message Bus trigger is used. Choose your device-name and reading name appropriately.
 
 ### SetRetryData()
 `SetRetryData(data []byte)`

--- a/docs_src/microservices/application/AppServiceConfigurable.md
+++ b/docs_src/microservices/application/AppServiceConfigurable.md
@@ -239,22 +239,6 @@ Required:
 
     There are many optional functions and parameters provided in this profile. See the [complete profile](https://github.com/edgexfoundry/app-service-configurable/blob/v2.0.0/res/mqtt-export/configuration.toml) for more details
 
-### push-to-core 
-
-Example profile demonstrating how to use the PushToCore function. Provided as an exmaple that can be copied and modified to create new custom profile. See the [complete profile](https://github.com/edgexfoundry/app-service-configurable/blob/v2.0.0/res/push-to-core/configuration.toml) for more details
-
-Requires further configuration which can easily be accomplished using environment variable overrides
-
-Required:
-
-- `WRITABLE_PIPELINE_FUNCTIONS_PUSHTOCORE_PROFILENAME: [Your Event's profile name]`
-- `WRITABLE_PIPELINE_FUNCTIONS_PUSHTOCORE_DEVICENAME: [Your Event's device name]`
-- `WRITABLE_PIPELINE_FUNCTIONS_PUSHTOCORE_SOURCENAME: [Your Event's source name]`
-- `WRITABLE_PIPELINE_FUNCTIONS_PUSHTOCORE_RESOURCENAME: [Your Event reading's resource name]`
-- `WRITABLE_PIPELINE_FUNCTIONS_PUSHTOCORE_VALUETYPE: [Your Event reading's value type]`
-- `WRITABLE_PIPELINE_FUNCTIONS_PUSHTOCORE_MEDIATYPE: [Your Event binary reading's media type]` 
-  - Required only when `ValueType` is `Binary`
-
 ### sample
 
 Sample profile with all available functions declared and a sample pipeline. Provided as a sample that can be copied and modified to create new custom profiles. See the [complete profile](https://github.com/edgexfoundry/app-service-configurable/blob/v2.0.0/res/sample/configuration.toml) for more details
@@ -630,29 +614,6 @@ Please refer to the function's detailed documentation by clicking the function n
 
 !!! edgey "EdgeX 2.0"
     For EdgeX 2.0 the `MQTTSecretSend` configurable pipeline function has been renamed to `MQTTExport` and the deprecated  `MQTTSend` configurable pipeline function has been removed
-
-### [PushToCore](../BuiltIn/#push-to-core-data)
-
-**Parameters**
-
-- `ProfileName` - Profile name to use for the new Event
-- `DeviceName` - Device name to use for  the new Event
-- `ResourceName` -  Resource name name to use for  the new Event's` SourceName` and Reading's `ResourceName`
-- `ValueType` - Value type to use  the new Event Reading's value type
-- `MediaType` - Media type to use the new Event Reading's value type. Required when the value type is `Binary`
-
-!!! example
-    ```toml
-        [Writable.Pipeline.Functions.PushToCore]
-          [Writable.Pipeline.Functions.PushToCore.Parameters]
-          ProfileName = "MyProfile"
-          DeviceName = "MyDevice"
-          ResourceName = "SomeResource"
-          ValueType = "String"
-    ```
-
-!!! edgey "EdgeX 2.0"
-    For EdgeX 2.0 the `ProfileName`, `ValueType` and `MediaType` parameters are new and the `ReadingName` parameter has been renamed to `ResourceName`. 
 
 ### [SetResponseData](../BuiltIn/#set-response-data)
 

--- a/docs_src/microservices/application/BuiltIn.md
+++ b/docs_src/microservices/application/BuiltIn.md
@@ -127,15 +127,6 @@ There is one Core Data function that enables interactions with the Core Data RES
 !!! edgey "EdgeX 2.1"
     The `NewCoreDataObejctReading`factory method is new for EdgeX 2.1
 
-### Push to Core Data
-
-`PushToCoreData` - This pipeline function provides the capability to push a new Event/Reading to Core Data. The data passed into this function from the pipeline is wrapped in an EdgeX Event with the Event and Reading metadata specified from the factory function options. The function returns the new EdgeX Event with ID populated.
-
-!!! example
-    ```go
-    NewCoreDataSimpleReading("my-profile", "my-device", "my-resource", "string").PushToCoreData
-    ```
-
 ## Event
 
 This enables the ability to wrap data into an Event/Reading


### PR DESCRIPTION
Signed-off-by: Marc-Philippe Fuller <marc-philippe.fuller@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
