### PR TITLE
fix: Change mkdocs and Docker port to 8008

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -22,4 +22,4 @@ RUN pip install mkdocs "mkdocs-material==8.5.8" "mkdocs-htmlproofer-plugin>=0.8"
 EXPOSE 8000
 
 ENTRYPOINT ["mkdocs"]
-CMD ["serve", "--dev-addr=0.0.0.0:8000"]
+CMD ["serve", "--dev-addr=0.0.0.0:8008"]

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ build-docs: build-docker
 		$(MKDOCS_IMAGE) \
 		build
 
-# Most common use case, serve docs on :8001 (8001 changed due to port conflicts with kong)
+# Most common use case, serve docs on :8008
 serve: build-docker
 	docker run --rm \
 		-it \
-		-p 8001:8000 \
+		-p 8008:8008 \
 		-v $(PWD):/docs \
 		-w /docs \
 		-e ENABLED_HTMLPROOFER \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The most common use case for local development of edgex-docs will be to verify c
 make serve
 ```
 
-Once running, you can view the rendered content locally and makes changes to your documentation and preview them in realtime with a browser at: http://0.0.0.0:8001/edgex-docs
+Once running, you can view the rendered content locally and makes changes to your documentation and preview them in realtime with a browser at:  
+http://0.0.0.0:8008
 
 ---
 


### PR DESCRIPTION
Kong's uses port 8001 for the admin API. So, if running the services natively or in snaps, `make serve` fails with error:

```
docker: Error response from daemon: driver failed programming external connectivity on endpoint eloquent_yonath (b91243329ae1088fa44762975cc9ad7944d7bbf9ecfcd30b6753fca3212c10ea): Error starting userland proxy: listen tcp4 0.0.0.0:8001: bind: address already in use.
```

```
$ sudo lsof -nPi :8001
COMMAND   PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
nginx   19104 root   13u  IPv4 152911      0t0  TCP 127.0.0.1:8001 (LISTEN)
...
```

Moreover, the docs port is set to 8001 in the Docker port mapping, resulting in confusing instructions in the mkdocs logs:
```
$ make serve
...
INFO     -  [11:25:19] Watching paths for changes: 'docs_src', 'mkdocs.yml'
INFO     -  [11:25:19] Serving on http://0.0.0.0:8000/
```
That URL (http://0.0.0.0:8000/) would either be Kong's (when running EdgeX with docker compose) or not accessible when not running EdgeX.

The PR changes the port to 8008 in both mkdocs server as well as the port mapping. It also removes the invalid `edgex-docs` from the path in readme.

Result:
```
$ make serve
...
INFO     -  [11:32:25] Watching paths for changes: 'docs_src', 'mkdocs.yml'
INFO     -  [11:32:25] Serving on http://0.0.0.0:8008/
```

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
