### PR TITLE
fix: replace references to UseTargetTypeOfByteArray and  UseTargetTyp…

### DIFF
--- a/docs_src/microservices/application/AppServiceConfigurable.md
+++ b/docs_src/microservices/application/AppServiceConfigurable.md
@@ -255,16 +255,16 @@ Profile used for the TAF functional testing  of external MQTT Trigger
 
 The default `TargetType` for data flowing into the functions pipeline is an EdgeX Event DTO. There are cases when this incoming data might not be an EdgeX Event DTO. There are two setting that configure the TargetType to non-Event data.
 
-### UseTargetTypeOfByteArray
+### Raw TargetType
 
- In these cases the `Pipeline` can be configured using `UseTargetTypeOfByteArray=true` to set the `TargetType` to be a byte array/slice, i.e. `[]byte`. The first function in the pipeline must then be one that can handle the `[]byte` data. The **compression**,  **encryption** and **export** functions are examples of pipeline functions that will take input data that is `[]byte`. 
+ In these cases the `Pipeline` can be configured using `TargetType="raw"` to set the `TargetType` to be a byte array/slice, i.e. `[]byte`. The first function in the pipeline must then be one that can handle the `[]byte` data. The **compression**,  **encryption** and **export** functions are examples of pipeline functions that will take input data that is `[]byte`. 
 
 !!! example "Example - Configure the functions pipeline to **compress**, **encrypt** and then **export** the `[]byte` data via HTTP "
     ```toml
     [Writable]
       LogLevel = "DEBUG"
       [Writable.Pipeline]
-        UseTargetTypeOfByteArray = true
+        TargetType = "raw"
         ExecutionOrder = "Compress, Encrypt, HTTPExport"
         [Writable.Pipeline.Functions.Compress]
           [Writable.Pipeline.Functions.Compress.Parameters]
@@ -289,17 +289,14 @@ If along with this pipeline configuration, you also configured the `Trigger` to 
     Type="http"
     ```
 
-### UseTargetTypeOfMetric
-
-!!! edgey "Edgex 2.2"
-    New for EdgeX 2.2 is the `UseTargetTypeOfMetric` setting
+### Metric TargetType
 
 This setting when set to true will cause the `TargeType` to be `&dtos.Metric{}` and is meant to be used in conjunction with the new `ToLineProtocol` function. See [ToLineProtocol](#tolineprotocol) section below for more details. In addition the `Trigger` `SubscribeTopics`must be set to `"edgex/telemetry/#"` so that the function receives the metric data from the other services.
 
-!!! example - "Example -  UseTargetTypeOfMetric "
+!!! example - "Example -  Metric TargetType "
     ```
       [Writable.Pipeline]
-      UseTargetTypeOfMetric  = true
+      TargetType  = "metric"
       ExecutionOrder = "ToLineProtocol, ..."
       ...
           [Writable.Pipeline.Functions.ToLineProtocol]
@@ -664,7 +661,7 @@ Please refer to the function's detailed documentation by clicking the function n
     ```
 
 !!! note
-    The new `UseTargetTypeOfMetric` setting must be set to true when using this function. See the [UseTargetTypeOfMetric](#usetargettypeofmetric) section above for more details.
+    The new `TargetType` setting must be set to "metric" when using this function. See the [Metric TargetType](#metric-targettype) section above for more details.
 
 ### [WrapIntoEvent](../BuiltIn/#wrap-into-event)
 


### PR DESCRIPTION
…eOfMetric to use new TargetType

Signed-off-by: Marc-Philippe Fuller <marc-philippe.fuller@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
