### PR TITLE
fix: Add missing default value for ConfigProvider command line flag

### DIFF
--- a/docs_src/microservices/configuration/CommonCommandLineOptions.md
+++ b/docs_src/microservices/configuration/CommonCommandLineOptions.md
@@ -33,7 +33,7 @@ Can be overridden with [EDGEX_CONFIG_FILE](./CommonEnvironmentVariables.md#edgex
 
 `-cp/ --configProvider`
 
-Indicates to use Configuration Provider service at specified URL. URL Format: `{type}.{protocol}://{host}:{port} ex: consul.http://localhost:8500`
+Indicates to use Configuration Provider service at specified URL. URL Format: `{type}.{protocol}://{host}:{port}`. Default is `consul.http://localhost:8500`
 
 Can be overridden with [EDGEX_CONFIG_PROVIDER](./CommonEnvironmentVariables.md#edgex_config_provider) environment variable.
 


### PR DESCRIPTION
close #940

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
