### PR TITLE
feat!: Remove Notify field out of Device DTO

### DIFF
--- a/docs_src/walk-through/Ch-WalkthroughProvision.md
+++ b/docs_src/walk-through/Ch-WalkthroughProvision.md
@@ -37,24 +37,23 @@ Use either the Postman or Curl tab below to walkthrough creating the `Device`.
             {
                 "apiVersion": "v2",
                 "device": {
-                "name": "countcamera1",
-                "description": "human and dog counting camera #1",
-                "adminState": "UNLOCKED",
-                "operatingState": "UP",
-                "labels": [
-                    "camera","counter"
-                ],
-                "location": "{lat:45.45,long:47.80}",
-                "serviceName": "camera-control-device-service",
-                "profileName": "camera-monitor-profile",
-                "protocols": {
-                    "camera-protocol": {
-                    "camera-address": "localhost",
-                    "port": "1234",
-                    "unitID": "1"
+                    "name": "countcamera1",
+                    "description": "human and dog counting camera #1",
+                    "adminState": "UNLOCKED",
+                    "operatingState": "UP",
+                    "labels": [
+                        "camera","counter"
+                    ],
+                    "location": "{lat:45.45,long:47.80}",
+                    "serviceName": "camera-control-device-service",
+                    "profileName": "camera-monitor-profile",
+                    "protocols": {
+                        "camera-protocol": {
+                            "camera-address": "localhost",
+                            "port": "1234",
+                            "unitID": "1"
+                        }
                     }
-                },
-                "notify": false
                 }
             }
         ]
@@ -74,7 +73,7 @@ Use either the Postman or Curl tab below to walkthrough creating the `Device`.
     Make a curl POST request as shown below.
 
     ``` shell
-    curl -X 'POST' 'http://localhost:59881/api/v2/device' -d '[{"apiVersion": "v2", "device": {"name": "countcamera1","description": "human and dog counting camera #1","adminState": "UNLOCKED","operatingState": "UP","labels": ["camera","counter"],"location": "{lat:45.45,long:47.80}","serviceName": "camera-control-device-service","profileName": "camera-monitor-profile","protocols": {"camera-protocol": {"camera-address": "localhost","port": "1234","unitID": "1"}},"notify": false}}]'
+    curl -X 'POST' 'http://localhost:59881/api/v2/device' -d '[{"apiVersion": "v2", "device": {"name": "countcamera1","description": "human and dog counting camera #1","adminState": "UNLOCKED","operatingState": "UP","labels": ["camera","counter"],"location": "{lat:45.45,long:47.80}","serviceName": "camera-control-device-service","profileName": "camera-monitor-profile","protocols": {"camera-protocol": {"camera-address": "localhost","port": "1234","unitID": "1"}}}}]'
     ```
 
     If your API call is successful, you will get a generated ID (a UUID) for your new `Device`.


### PR DESCRIPTION
Per https://github.com/edgexfoundry/edgex-go/pull/4375 and https://github.com/edgexfoundry/go-mod-core-contracts/pull/807, the notify field of Device DTO is removed, so that documentation should be updated to remove the notify field as well.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
