### PR TITLE
fix: fix sitemap for Kamakura release to have version in sitemap.xml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ docs_dir: ./docs_src
 site_dir: ./docs/2.2
 site_description: 'Documentation for use of EdgeX Foundry'
 site_author: 'Michael Johanson'
-site_url: 'https://edgexfoundry.github.io/edgex-docs/'
+site_url: 'https://edgexfoundry.github.io/edgex-docs/2.2'
 repo_url: 'https://github.com/edgexfoundry/edgex-go'
 repo_name: 'edgex/edgex-go'
 copyright: 'Copyright &copy; 2022 EdgeX Foundry'


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
