### PR TITLE
feat: Document the URL escape for device command name and resource name

### DIFF
--- a/docs_src/getting-started/Ch-GettingStartedDTOValidation.md
+++ b/docs_src/getting-started/Ch-GettingStartedDTOValidation.md
@@ -37,3 +37,6 @@ This validation allows for only the following characters:
 
      - In BACNet protocol, the user might combine object type and property as the resourceName, for example, analog_input_0:present-value
      - In OPC_UA protocol, the user might use NodeId as the resourceName, for example, ns=10;s=Hello:World
+
+!!! edgey "EdgeX 3.0"
+    In EdgeX 3.0, the character restriction was reduced for the command name and resource name because some protocols may use `/` or `.` in the name. By using URL escaping for the API, device command name and resource name allow various characters. For example, the user can define the command name `line-a/test:value` and use it with URL escaping as `/api/v2/device/name/Modbus-TCP-Device/line-a%2Ftest%3Avalue`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,6 @@ nav:
         - './getting-started/Ch-GettingStartedUsers.md'
         - './getting-started/Ch-GettingStartedDockerUsers.md'
         - './getting-started/Ch-GettingStartedSnapUsers.md'
-        - './getting-started/Ch-GettingStartedDTOValidation.md'
       - Developers:
         - './getting-started/Ch-GettingStartedDevelopers.md'
         - './getting-started/Ch-GettingStartedGoDevelopers.md'
@@ -42,6 +41,7 @@ nav:
           - './getting-started/Ch-GettingStartedSDK-C.md'
           - './getting-started/Ch-GettingStartedSDK-Go.md'
         - './getting-started/Ch-GettingStartedUsersNexus.md'
+        - './getting-started/Ch-GettingStartedDTOValidation.md'
       - Tools:
         - './getting-started/tools/Ch-CommandLineInterface.md'
         - './getting-started/tools/Ch-GUI.md'


### PR DESCRIPTION
- Document the restriction was reduced for the command name and resource name, and usage of URL escape for API.
- Move this page to the Developers section

Close #979 #950

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
