### PR TITLE
fix: Bring security docs up to do date

### DIFF
--- a/docs_src/security/Ch-APIGateway.md
+++ b/docs_src/security/Ch-APIGateway.md
@@ -98,7 +98,7 @@ will hang on startup in order to prompt for a password.
 Run the following command to install a custom certificate
 using the assumptions above:
 
-    docker compose -p edgex -f docker-compose.yml run --rm -v `pwd`:/host:ro --entrypoint /edgex/secrets-config proxy-setup proxy tls --incert /host/cert.pem --inkey /host/key.pem
+    docker compose -p edgex -f docker-compose.yml run --rm -v `pwd`:/host:ro --entrypoint /edgex/secrets-config proxy-setup proxy tls --inCert /host/cert.pem --inKey /host/key.pem
 
 The following command can verify the certificate installation was successful.
 


### PR DESCRIPTION
Recent changes to secrets-config tool

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
