### PR TITLE
feat: Update and cleanup snap v3 security getting started

### DIFF
--- a/docs_src/getting-started/Ch-GettingStartedSnapUsers.md
+++ b/docs_src/getting-started/Ch-GettingStartedSnapUsers.md
@@ -385,7 +385,7 @@ The API gateway will pass any request that authenticates using a
 
 The baseline implementation in EdgeX 3.0 uses Vault identity and the 'userpass' authentication engine to create users,
 though EdgeX adopters are free to add their own Vault identities using authentication methods of their choice.
-To add a new user locally, use the snapped `edgexfoundry.secrets-config` utility.
+To add a new user locally, use the snapped `secrets-config` utility.
 
 To get the usage help:
 ```bash
@@ -395,9 +395,9 @@ You may also refer to the [secrets-config proxy](../../security/secrets-config-p
 
 
 !!! example "Creating an example user"
-    Use secrets-config to add a user `example` (note: always specify `--useRootToken` for the snap deployment of EdgeX):
+    Use `secrets-config` to add an `example` user (note: always specify `--useRootToken` for the snap deployment of EdgeX):
     ```bash
-    edgexfoundry.secrets-config proxy adduser --user example --useRootToken
+    sudo edgexfoundry.secrets-config proxy adduser --user example --useRootToken
     ```
     On success, the above command prints a JSON object containing `username` and `password` fields.
     If the "adduser" command is run multiple times,
@@ -409,13 +409,13 @@ You may also refer to the [secrets-config proxy](../../security/secrets-config-p
 
     ```bash
     username=example
-    password=password-from-above
+    password=<password-from-above>
     
-    vault_token=$(curl -ks "http://localhost:8200/v1/auth/userpass/login/${username}" -d "{\"password\":\"${password}\"}" | jq -r '.auth.client_token')
+    vault_token=$(curl --silent --show-err "http://localhost:8200/v1/auth/userpass/login/${username}" -d "{\"password\":\"${password}\"}" | jq --raw-output '.auth.client_token')
     
-    id_token=$(curl -ks -H "Authorization: Bearer ${vault_token}" "http://localhost:8200/v1/identity/oidc/token/${username}" | jq -r '.data.token')
+    id_token=$(curl --silent --show-err -H "Authorization: Bearer ${vault_token}" "http://localhost:8200/v1/identity/oidc/token/${username}" | jq --raw-output '.data.token')
     
-    echo "${id_token}" > user-jwt.txt
+    echo "${id_token}" > id_token.txt
     ```
 
 Once you have the token, you can access the services via the API Gateway (the vault token can be discarded).
@@ -424,7 +424,7 @@ To obtain a new JWT token once the current one is expired, repeat the above snip
 !!! example "Calling an API on behalf of example user"
 
     ```bash
-    curl --insecure https://localhost:8443/core-data/api/v2/ping -H "Authorization: Bearer $(cat user-jwt.txt)"
+    curl --insecure https://localhost:8443/core-data/api/v2/ping -H "Authorization: Bearer $(cat id_token.txt)"
     ```
     Output: `{"apiVersion":"v2","timestamp":"Mon May  2 12:14:17 CEST 2022","serviceName":"core-data"}`
 
@@ -452,16 +452,23 @@ Consul API and UI can be accessed using the consul token (Secret ID). For the sn
 #### Changing TLS certificates
 The API Gateway setup generates a self-signed certificate with a short expiration by default.
 
-The default certificate is stored at `/var/snap/edgexfoundry/current/nginx/nginx.crt`.
-
-The default private key is stored at `/var/snap/edgexfoundry/current/nginx/nginx.key`.
-
 The JWT authentication token that is consumed by the proxy is sensitive and it is important that
 measures are taken to ensure that clients do not disclose the JWT to unauthorized parties.
 For this reason, the default certificate and key should be replaced
 with a certificate and key that is trusted by connecting clients.
-(This can be done a `sudo cp` command or equivalent.)
 
+The certificate and key can be replaced locally. They are located at:
+
+- `/var/snap/edgexfoundry/current/nginx/nginx.crt`
+- `/var/snap/edgexfoundry/current/nginx/nginx.key`
+
+Changes to the files should be followed by reloading Nginx: `sudo snap restart --reload edgexfoundry.nginx`
+
+Alternatively, the certificate and key can be replaced using the snapped `secrets-config` application. To get the usage help:
+```bash
+edgexfoundry.secrets-config proxy tls -h
+```
+Refer to the [secrets-config proxy](../../security/secrets-config-proxy/) documentation.
 
 !!! example
     Given the following files created outside the scope of this document:
@@ -469,24 +476,37 @@ with a certificate and key that is trusted by connecting clients.
     * `nginx.crt` user-provided certificate (replacing the default)
     * `nginx.key` user-provided private key (replacing the default)
     * `ca.pem` certificate authority file (that signed `nginx.crt`, directly or indirectly)
+  
+    available at a directory accessible to the snapped application (e.g. `/var/snap/edgexfoundry/current/tmp/`), the certificate and key can be replaced as follows:
+
+    1. Add new certificate files:
+    ```bash
+    sudo edgexfoundry.secrets-config proxy tls \
+      --targetFolder /var/snap/edgexfoundry/current/nginx \
+      --inCert /var/snap/edgexfoundry/current/tmp/nginx.crt \
+      --inKey  /var/snap/edgexfoundry/current/tmp/nginx.key 
+    ```
+    2. Remove the temporary directory
+    
+    3. Reload Nginx:
+    ```bash
+    sudo snap restart --reload edgexfoundry.nginx
+    ```
+
+    Instead of temporarily adding the files to the snap, the files can be loaded directly from the root user's home (`/root`) or as a removable media, after granting the [home](https://snapcraft.io/docs/home-interface) or [removable-media](https://snapcraft.io/docs/removable-media-interface) permissions.
     
     Try it out:
     ```bash
     curl --cacert ca.pem https://localhost:8443/core-data/api/v2/ping
     ```
-    Output: `{"message":"Unauthorized"}`  
-    This means that TLS is setup correctly, but the request is not authorized.  
-    Set the `-v` command for diagnosing TLS issues.  
+    The output would include a message such as: `401 Authorization Required`
+
+    This means that TLS is setup correctly, but the request is not authorized since it is missing the required authentication.
+
+    Set the `-v` command for diagnosing TLS issues.
+
     The `--cacert` can be omitted if the CA is available in root certificates (e.g. CA-signed or pre-installed CA certificate).
 
-
-??? tip "Seeding a custom TLS certificate using snap options"
-    To spin up an EdgeX instance with a custom certificate, the snap provides the following configuration options:
-    
-    * `apps.secrets-config.proxy.tls.cert`
-    * `apps.secrets-config.proxy.tls.key`
-    
-    This is particularly useful when seeding the snap from a [Gadget](https://snapcraft.io/docs/gadget-snap) on an [Ubuntu Core](https://ubuntu.com/core) system.
 
 <!-- DO NOT CHANGE THE TITLE. READMEs reference the anchor -->
 #### Secret Store token

--- a/docs_src/getting-started/Ch-GettingStartedSnapUsers.md
+++ b/docs_src/getting-started/Ch-GettingStartedSnapUsers.md
@@ -370,14 +370,10 @@ Upon installation, the following EdgeX services are automatically started:
 - security-proxy-setup (oneshot service to setup API gateway)
 - security-secretstore-setup (oneshot service to setup Vault)
 - vault (Secret Store)
-
-The following services are disabled by default:
-
 - support-notifications
 - support-scheduler
-- sys-mgmt-agent - *deprecated EdgeX component*
 
-The disabled services can be manually enabled and started; see [managing services].
+The services can be disabled and stopped; see [managing services].
 
 For the configuration of services, refer to [configuration].
 


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)


## Testing instructions for the TLS certs
Create and run the following bash script:
```bash
#!/bin/bash -ex

SERVER_CERT_FILE=server.crt
SERVER_KEY_FILE=server.key
SERVER_CSR_FILE=server.csr
CA_CERT_FILE=ca.crt
CA_KEY_FILE=ca.key
TEMP_DIR=/var/snap/edgexfoundry/common

# Generate the Certificate Authority (CA) Private Key
openssl ecparam -name prime256v1 -genkey -noout -out $CA_KEY_FILE
# Generate the Certificate Authority Certificate
openssl req -new -x509 -sha256 -key $CA_KEY_FILE -out $CA_CERT_FILE -subj "/CN=local-ca"
# Generate the Server Certificate Private Key
openssl ecparam -name prime256v1 -genkey -noout -out $SERVER_KEY_FILE
# Generate the Server Certificate Signing Request
openssl req -new -sha256 -key $SERVER_KEY_FILE -out $SERVER_CSR_FILE -subj "/CN=localhost"
# Generate the Server Certificate
openssl x509 -req -in $SERVER_CSR_FILE -CA $CA_CERT_FILE -CAkey $CA_KEY_FILE -CAcreateserial -out $SERVER_CERT_FILE -days 1000 -sha256

sudo cp $SERVER_CERT_FILE $SERVER_KEY_FILE $TEMP_DIR/

sudo edgexfoundry.secrets-config proxy tls \
    --inCert $TEMP_DIR/$SERVER_CERT_FILE \
    --inKey $TEMP_DIR/$SERVER_KEY_FILE \
    --targetFolder /var/snap/edgexfoundry/current/nginx

sudo rm $SERVER_CERT_FILE $SERVER_KEY_FILE

sudo snap restart --reload edgexfoundry.nginx

sleep 1

curl --cacert $CA_CERT_FILE -v https://localhost:8443/core-data/api/v2/ping
```