### PR TITLE
docs: update SecretProviderAPI (go-mod-bootstrap/522)

### DIFF
--- a/docs_src/security/Ch-SecretProviderApi.md
+++ b/docs_src/security/Ch-SecretProviderApi.md
@@ -15,7 +15,7 @@ type SecretProvider interface {
     HasSecret(secretName string) (bool, error)
 	ListSecretNames() ([]string, error)
 	SecretsLastUpdated() time.Time	
-    RegisteredSecretUpdatedCallback(secretName string, callback func(path string)) error
+    RegisterSecretUpdatedCallback(secretName string, callback func(secretName string)) error
 	DeregisterSecretUpdatedCallback(secretName string)
 }
 ```
@@ -24,7 +24,7 @@ type SecretProvider interface {
 
 `StoreSecret(secretName string, secrets map[string]string) error`
 
-Stores new secrets into the service's SecretStore at the specified path (aka secret name). An error is returned if the secrets can not be stored.
+Stores new secrets into the service's SecretStore at the specified `secretName`. An error is returned if the secrets can not be stored.
 
 !!! note 
     This API is only valid to call when in secure mode. It will return an error when in non-secure mode. Insecure Secrets should be added/updated directly in the configuration file or via the Configuration Provider (aka Consul).
@@ -33,19 +33,19 @@ Stores new secrets into the service's SecretStore at the specified path (aka sec
 
 `GetSecret(secretName string, keys ...string) (map[string]string, error)`
 
-Retrieves the secrets from the service's SecretStore for the specified path (aka secret name). The list of keys is optional and limits the secret data returned to just those keys specified, otherwise all keys are returned. An error is returned if the path doesn't exist in the service's Secret Store or if one or more of the optional keys specified are not present.
+Retrieves the secrets from the service's SecretStore for the specified `secretName`. The list of keys is optional and limits the secret data returned to just those keys specified, otherwise all keys are returned. An error is returned if the `secretName` doesn't exist in the service's Secret Store or if one or more of the optional keys specified are not present.
 
 ### HasSecret 
 
 `HasSecret(secretName string) (bool, error)`
 
-Returns true if the service's Secret Store contains a secret at the specified path  (aka secret name) . An error is retuned if the Secret Store can not be accessed.
+Returns true if the service's Secret Store contains a secret at the specified `secretName`. An error is returned if the Secret Store can not be accessed.
 
 ### ListSecretNames 
 
 `ListSecretNames() ([]string, error)`
 
-Returns a list of paths (aka secret names) from the current service's Secret Store. An error is retuned if the Secret Store can not be accessed.
+Returns a list of secret names from the current service's Secret Store. An error is returned if the Secret Store can not be accessed.
 
 ### SecretsLastUpdated 
 
@@ -53,14 +53,20 @@ Returns a list of paths (aka secret names) from the current service's Secret Sto
 
 Returns the timestamp for last time when the service's secrets were updated in its Secret Store. This is useful when using external client that is initialized with the secret and needs to be recreated if the secret has changed. 
 
-### RegisteredSecretUpdatedCallback
+### RegisterSecretUpdatedCallback
 
-    RegisteredSecretUpdatedCallback(secretName string, callback func(path string)) error
+    RegisterSecretUpdatedCallback(secretName string, callback func(secretName string)) error
 
-Registers a callback for when the  specified `secretName` is added or updated.
+Registers a callback for when the specified `secretName` is added or updated. The `secretName` that changed is provided as an argument to the callback so that the same callback can be utilized for multiple secrets if desired.
+
+!!! note
+    The constant value `secret.WildcardName` can be used to register a callback for when _any_ secret has changed. The actual `secretName` that changed will be passed to the callback. Note that the callbacks set for a specific `secretName` are given a higher precedence over wildcard ones, and will be called _instead of_ the wildcard one if both are present.
+
+!!! note
+    This function will return an error if there is already a callback registered for the specified `secretName`. Please call `DeregisterSecretUpdatedCallback` first before attempting to register a new one.
 
 ### DeregisterSecretUpdatedCallback
 
     DeregisterSecretUpdatedCallback(secretName string)
 
-Removes the registered callback for the specified `secretName`
+Removes the registered callback for the specified `secretName`. If none exist, this is a no-op.


### PR DESCRIPTION
- Change path to secretName
- Rename RegisteredSecretUpdatedCallback to RegisterSecretUpdatedCallback
- Add notes on wildcard usage

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)

https://github.com/edgexfoundry/go-mod-bootstrap/pull/522
