### PR TITLE
fix: Remove release macro (again)

### DIFF
--- a/docs_src/getting-started/Ch-GettingStartedDockerUsers.md
+++ b/docs_src/getting-started/Ch-GettingStartedDockerUsers.md
@@ -40,7 +40,8 @@ Locate the branch containing the EdgeX Docker Compose file for the version of Ed
 !!! Note
     The `main` branch contains the Docker Compose files that use artifacts created from the latest code submitted by contributors (from the night builds).  Most end users should avoid using these Docker Compose files.  They are work-in-progress.  Users should use the Docker Compose files for the latest version of EdgeX. 
 
-In each edgex-compose branch, you will find several Docker Compose files (all with a .yml extension).  The name of the file will suggest the type of EdgeX instance the Compose file will help setup.  The table below provides a list of the Docker Compose filenames for the latest release ({{release}}).   Find the Docker Compose file that matches:
+In each edgex-compose branch, you will find several Docker Compose files (all with a .yml extension).  The name of the file will suggest the type of EdgeX instance the Compose file will help setup.  The table below provides a list of the Docker Compose filenames for the `{{version}}` release.
+Find the Docker Compose file that matches:
 
 - your hardware (x86 or ARM)
 - your desire to have security services on or off

--- a/docs_src/getting-started/Ch-GettingStartedDockerUsers.md
+++ b/docs_src/getting-started/Ch-GettingStartedDockerUsers.md
@@ -40,7 +40,7 @@ Locate the branch containing the EdgeX Docker Compose file for the version of Ed
 !!! Note
     The `main` branch contains the Docker Compose files that use artifacts created from the latest code submitted by contributors (from the night builds).  Most end users should avoid using these Docker Compose files.  They are work-in-progress.  Users should use the Docker Compose files for the latest version of EdgeX. 
 
-In each edgex-compose branch, you will find several Docker Compose files (all with a .yml extension).  The name of the file will suggest the type of EdgeX instance the Compose file will help setup.  The table below provides a list of the Docker Compose filenames for the `{{version}}` release.
+In each edgex-compose branch, you will find several Docker Compose files (all with a .yml extension).  The name of the file will suggest the type of EdgeX instance the Compose file will help setup.  The table below provides a list of the Docker Compose filenames for the `{{version}}` version.
 Find the Docker Compose file that matches:
 
 - your hardware (x86 or ARM)

--- a/docs_src/getting-started/quick-start/index.md
+++ b/docs_src/getting-started/quick-start/index.md
@@ -14,7 +14,7 @@ Install the following:
 ## Running EdgeX
 
 !!! Info
-    {{release}} ({{version}}) is the latest version of EdgeX and used by example in this guide.
+    The version of EdgeX used in the following examples is `{{version}}`.
 
 Once you have Docker and Docker Compose installed, you need to:
 

--- a/template_macros.yaml
+++ b/template_macros.yaml
@@ -9,7 +9,6 @@
 #
 # Examples: main, v3.0, v3.1
 version: main
-release: Minnesota
 
 # api_version is the major API version
 #


### PR DESCRIPTION
We had an extensive discussion in https://github.com/edgexfoundry/edgex-docs/pull/1000 and working group calls which ended with keeping only the minor version and API version as macros. The release field was added again in https://github.com/edgexfoundry/edgex-docs/pull/1074 without any description.

This is confusing and unnecessary:
- The macro can be misused in Github URLs, leading to issues discussed in [#1000](https://github.com/edgexfoundry/edgex-docs/pull/1000#discussion_r1154378996)
- The uses for the added macro is misleading, telling the reader something is the "latest" release or version which ends up becoming invalid at the next release.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
