### PR TITLE
fix: Use localhost for browsing locally served docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ make serve
 ```
 
 Once running, you can view the rendered content locally and makes changes to your documentation and preview them in realtime with a browser at:  
-http://0.0.0.0:8008
+http://localhost:8008
 
 ---
 


### PR DESCRIPTION
Although some systems accept [0.0.0.0](https://en.wikipedia.org/wiki/0.0.0.0) as the destination address for the loopback (127.0.0.1 or localhost), it is strange and looks like a mistake.



<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
