### PR TITLE
fix: [kamakura] Correct published port number for Device GPIO

### DIFF
--- a/docs_src/general/ServicePorts.md
+++ b/docs_src/general/ServicePorts.md
@@ -43,7 +43,7 @@ The following tables (organized by type of service) capture the default service 
     |device-rfid-llrp    |59989|
     |device-grove   |59992|
     |device-snmp	|59993|
-    |device-gpio    |59994|
+    |device-gpio    |59910|
 === "Security"
     |Services Name|	Port Definition|
     |---|---|


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
