### PR TITLE
fix: Pre-defined example for MQTT

### DIFF
--- a/docs_src/examples/Ch-ExamplesAddingMQTTDevice.md
+++ b/docs_src/examples/Ch-ExamplesAddingMQTTDevice.md
@@ -36,19 +36,17 @@ Create the device configuration file, named `my.custom.device.config.yaml`, as s
 ```yaml
 # Pre-define Devices
 deviceList:
-  name: "my-custom-device"
+- name: "my-custom-device"
   profileName: "my-custom-device-profile"
   description: "MQTT device is created for test purpose"
-  labels: 
-    - "MQTT"
-    - "test"
+  labels: [ "MQTT", "test" ]
   protocols:
     mqtt:
-       CommandTopic: "command/my-custom-device"
+      CommandTopic: "command/my-custom-device"
   autoEvents:
-   interval: "30s"
-   onChange: false
-   sourceName: "message"
+    - interval: "30s"
+      onChange: false
+      sourceName: "message"
 ```
 
 !!! note


### PR DESCRIPTION
The example now it works for MQTT devices.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

<!-- **If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md -->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
