### PR TITLE
fix: scale format integer format in yml example

### DIFF
--- a/docs_src/examples/Ch-ExamplesAddingModbusDevice.md
+++ b/docs_src/examples/Ch-ExamplesAddingModbusDevice.md
@@ -103,7 +103,7 @@ deviceResources:
     properties:
       valueType: "Float32"
       readWrite: "RW"
-      scale: "0.1"
+      scale: 0.1
   -
     name: "ThermostatH"
     isHidden: true
@@ -113,7 +113,7 @@ deviceResources:
     properties:
       valueType: "Float32"
       readWrite: "RW"
-      scale: "0.1"
+      scale: 0.1
   -
     name: "AlarmMode"
     isHidden: true
@@ -132,7 +132,7 @@ deviceResources:
     properties:
       valueType: "Float32"
       readWrite: "R"
-      scale: "0.1"
+      scale: 0.1
 
 deviceCommands:
   -
@@ -179,7 +179,7 @@ deviceResources:
     properties:
       valueType: "Float32"
       readWrite: "R"
-      scale: "0.1"
+      scale: 0.1
 ```
 
 In the device-modbus, the Property `valueType` decides how many registers will be read. Like


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
The example given for the modbus has the scale value as string, and it must be a number as it can be located in the given example in the modbus device service https://github.com/edgexfoundry/device-modbus-go/blob/main/cmd/res/profiles/modbus.test.device.profile.yml

<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
