### PR TITLE
feat: Add LastConnected metric to common config

### DIFF
--- a/docs_src/microservices/device/Ch-DeviceServices.md
+++ b/docs_src/microservices/device/Ch-DeviceServices.md
@@ -149,6 +149,7 @@ Please refer to the general [Common Configuration documentation](../configuratio
     |Metrics|     |Service metrics that the device service collects. Boolean value indicates if reporting of the metric is enabled. Common and custom metrics are also included.|
     ||`EventsSent` = false     |Enable/disable reporting of the built-in **EventsSent** metric|
     ||`ReadingsSent` = false     |Enable/disable reporting of the built-in **ReadingsSent** metric|
+    ||`LastConnected` = false     |Enable/disable reporting of the built-in **LastConnected** metric|
     ||`<CustomMetric>` = false    |Enable/disable reporting of custom device service's custom metric. See [Custom Device Service Metrics](../../getting-started/Ch-GettingStartedSDK-Go/#built-in) for more details.|
     |Tags|`<empty>`|List of arbitrary service level tags to included with every metric that is reported.  |
 === "Clients.core-metadata*"


### PR DESCRIPTION
fixes #1230. Add LastConnected metric to device service common config.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
