### PR TITLE
fix: Set ENABLED_HTMLPROOFER=true only on PR validation(napa)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,9 +10,6 @@ pipeline {
     triggers {
         issueCommentTrigger('.*^recheck$.*')
     }
-    environment {
-        ENABLED_HTMLPROOFER = true
-    }
     stages {
         stage('Build Docs') {
             agent {
@@ -23,11 +20,16 @@ pipeline {
                 }
             }
             steps {
-                retry(4) {
-                    sh 'mkdocs build'
-                    sh 'sleep 5' // add a little delay to avoid potential rate limiting issues
-                }
+                script {
+                    if ((env.BRANCH_NAME).startsWith('PR-')) {
+                        env.ENABLED_HTMLPROOFER = true
+                    }
 
+                    retry(4) {
+                        sh 'mkdocs build'
+                        sh 'sleep 5' // add a little delay to avoid potential rate limiting issues
+                    }
+                }
                 // stash the site contents generated from mkdocs build
                 stash name: 'site-contents', includes: 'docs/**', useDefaultExcludes: false
             }


### PR DESCRIPTION
Set ENABLED_HTMLPROOFER=true only on PR validation

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
