### PR TITLE
fix: Update GettingStartedSDK-C.md

### DIFF
--- a/docs_src/microservices/device/sdk/devicesdk-getting-started/GettingStartedSDK-C.md
+++ b/docs_src/microservices/device/sdk/devicesdk-getting-started/GettingStartedSDK-C.md
@@ -212,7 +212,21 @@ sends to EdgeX.
 3.  Run your device service:
 
     ``` bash
-    ./device-example-c
+    ./device-example-c -cp=keeper.http://localhost:59890
+    ```
+    The `-cp` flag tells the device service where to find the [Configuration Provider](../../../configuration/ConfigurationAndRegistry.md#configuration-provider). In this case, the configuration provider is the `Core Keeper` service running on port 59890.
+    If not using the Configuration Provider, you must specify the location of the common configuration file using the `-cc\--commonConfig` flag. For example:
+
+    ``` bash
+    ./device-example-c -cc /path/to/configuration.yaml
+    ```
+    See the [Common Configuration](../../../configuration/CommonConfiguration.md) for list of all the common configuration settings.
+    
+    See the [edgex-go/cmd/core-common-config-bootstrapper/res/configuration.yaml](https://github.com/edgexfoundry/edgex-go/blob/main/cmd/core-common-config-bootstrapper/res/configuration.yaml) for an example of the common configuration file.
+
+    Furthermore, if the device service is to be registered with the [Registry Provider](../../../configuration/ConfigurationAndRegistry.md#registry-provider), the `-r/--registry` flag must be used. For example:
+    ``` bash
+    ./device-example-c -cp=keeper.http://localhost:59890 -r
     ```
 
 4.  You should now see your device service having its /Random command


### PR DESCRIPTION
Due to the introduction of the common configuration in v3, the device service now requires either the `-cc/--commonConfig` or `-cp/--configProvider` flag during startup.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
