### PR TITLE
feat: Add doc for obtaining Postgres superuser pw

### DIFF
--- a/docs_src/security/Ch-SecretStore.md
+++ b/docs_src/security/Ch-SecretStore.md
@@ -51,9 +51,9 @@ Each EdgeX microservice has access to a `StoreSecrets()` method that allows
 setting of per-microservice secrets, and a `GetSecrets()` method to read them back.
 
 If manual "super-user" to the EdgeX secret store is required,
-it is necesary to obtain a privileged access token, called the Vault root token.
+it is necessary to obtain a privileged access token, called the OpenBao root token.
 
-### Obtaining the Vault Root Token
+### Obtaining the OpenBao Root Token
 
 For security reasons (the 
 [OpenBao production hardening guide](https://openbao.org/docs/concepts/tokens/#root-tokens)
@@ -63,7 +63,7 @@ and provides a programmatic interface for individual microservices
 to interact with their partition of the secret store.
 
 If global access to the secret store is required,
-it is necessary to obtain a copy of the Vault root token
+it is necessary to obtain a copy of the OpenBao root token
 using the below recommended procedure.
 Note that following this procedure directly contradicts the
 [OpenBao production hardening guide](https://openbao.org/docs/concepts/tokens/#root-tokens).
@@ -94,7 +94,7 @@ docker run --rm -ti -v edgex_secret-store-config:/openbao/config:ro alpine:lates
 
 
 As an alternative to overriding `SECRETSTORE_REVOKEROOTTOKENS` from the beginning,
-it is possible to regenerate the root token from the Vault unseal keys
+it is possible to regenerate the root token from the OpenBao unseal keys
 in `resp-init.json` 
 using the [OpenBao's documented procedure](https://openbao.org/docs/concepts/tokens/#root-tokenst).
 The EdgeX framework executes this process internally whenever it requires root token capability.
@@ -103,15 +103,15 @@ if `SECRETSTORE_REVOKEROOTTOKENS` remains set to its default value: all root tok
 are revoked every time the framework is started if `SECRETSTORE_REVOKEROOTTOKENS` is `true`.
 
 
-### Using the Vault CLI
+### Using the OpenBao CLI
 
-Execute a shell session in the running Vault container:
+Execute a shell session in the running OpenBao container:
 
 ```bash
   docker exec -it edgex-secret-store sh -l
 ```
 
-Login to Vault using Vault CLI and the gathered Root Token:
+Login to OpenBao using OpenBao CLI and the gathered Root Token:
 
 ```
 edgex-secret-store:/# bao login s.ULr5bcjwy8S0I5g3h4xZ5uWa
@@ -193,13 +193,13 @@ password            9/crBba5mZqAfAH8d90m7RlZfd7N8yF2IVul89+GEaG3
 username            redis5
 ```
 
-With the root token, it is possible to modify any Vault setting.
+With the root token, it is possible to modify any OpenBao setting.
 See the [Openbao manuals](https://openbao.org/docs/commands/) for available commands.
 
 
-### Use the Vault REST API
+### Use the OpenBao REST API
 
-Vault also supports a REST API with functionality equivalent to the command line interface:
+OpenBao also supports a REST API with functionality equivalent to the command line interface:
 
 The equivalent of the
 

--- a/docs_src/security/Ch-Secure-Postgres.md
+++ b/docs_src/security/Ch-Secure-Postgres.md
@@ -1,0 +1,40 @@
+# Secure PostgreSQL
+
+The superuser password of PostgreSQL will be generated randomly and securely stored in the secret store with security service enabled.
+
+To retrieve the PostgreSQL superuser password, you can use the following methods:
+
+### Obtaining superuser password using the OpenBao CLI
+
+1. Follow the instructions from [Obtaining the OpenBao Root Token](Ch-SecretStore.md#obtaining-the-openbao-root-token) to get the OpenBao root token.
+2. Follow the instructions from [Using the OpenBao CLI](Ch-SecretStore.md#using-the-openbao-cli) to launch the OpenBao CLI.
+3. Retrieve the superuser password by executing the following command in the OpenBao CLI:
+    ```
+    edgex-secret-store:/# bao read secret/edgex/security-bootstrapper-postgres/postgres
+    Key                 Value
+    ---                 -----
+    refresh_interval    168h
+    password            EMletY2JCkOT6lEzZ72f2vo89/hpg/CIcj25Gdk3zMCt
+    username            postgres
+    ```
+
+### Obtaining superuser password using the OpenBao REST API
+
+1. Follow the instructions from [Obtaining the OpenBao Root Token](Ch-SecretStore.md#obtaining-the-openbao-root-token) to get the OpenBao root token.
+2. Display (GET) the postgres credentials from the `security-bootstrapper-postgres` secret store by using the OpenBao API:
+   ```
+   curl -s -H 'X-Vault-Token: <OpenBao-Root-Token>' http://localhost:8200/v1/secret/edgex/security-bootstrapper-postgres/postgres | python -m json.tool
+   {
+       "request_id": "e4e8f2e2-3185-6955-92ed-be725c3387fc",
+       "lease_id": "",
+       "renewable": false,
+       "lease_duration": 604800,
+       "data": {
+           "password": "EMletY2JCkOT6lEzZ72f2vo89/hpg/CIcj25Gdk3zMCt",
+           "username": "postgres"
+       },
+       "wrap_info": null,
+       "warnings": null,
+       "auth": null
+   }
+   ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -332,6 +332,7 @@ nav:
       - security/Ch-SecretProviderApi.md
       - security/Ch-APIGateway.md
       - security/Ch-Secure-MessageBus.md
+      - security/Ch-Secure-Postgres.md
       - security/Ch-Configuring-Add-On-Services.md
       - security/Ch-Secure-Consul.md
       - security/Ch-SecurityIssues.md


### PR DESCRIPTION
Relates to #1410. Add doc for obtaining Postgres superuser password via secret store.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
