### PR TITLE
fix: Add the client_token instruction

### DIFF
--- a/docs_src/security/Ch-Secure-Postgres.md
+++ b/docs_src/security/Ch-Secure-Postgres.md
@@ -6,8 +6,8 @@ To retrieve the PostgreSQL superuser password, you can use the following methods
 
 ### Obtaining superuser password using the OpenBao CLI
 
-1. Follow the instructions from [Obtaining the OpenBao Root Token](Ch-SecretStore.md#obtaining-the-openbao-root-token) to get the OpenBao root token.
-2. Follow the instructions from [Using the OpenBao CLI](Ch-SecretStore.md#using-the-openbao-cli) to launch the OpenBao CLI.
+1. Follow the instructions from [Obtaining the OpenBao Root Token](Ch-SecretStore.md#obtaining-the-openbao-root-token) to get the OpenBao root token or use the `client_token` stored in `/tmp/edgex/secrets/security-bootstrapper-postgres/secrets-token.json`.
+2. Follow the instructions from [Using the OpenBao CLI](Ch-SecretStore.md#using-the-openbao-cli) to launch the OpenBao CLI and login in with the OpenBao root token or the `security-bootstrapper-postgres`'s `client-token`.
 3. Retrieve the superuser password by executing the following command in the OpenBao CLI:
     ```
     edgex-secret-store:/# bao read secret/edgex/security-bootstrapper-postgres/postgres
@@ -20,10 +20,10 @@ To retrieve the PostgreSQL superuser password, you can use the following methods
 
 ### Obtaining superuser password using the OpenBao REST API
 
-1. Follow the instructions from [Obtaining the OpenBao Root Token](Ch-SecretStore.md#obtaining-the-openbao-root-token) to get the OpenBao root token.
+1. Follow the instructions from [Obtaining the OpenBao Root Token](Ch-SecretStore.md#obtaining-the-openbao-root-token) to get the OpenBao root token or use the `client_token` stored in `/tmp/edgex/secrets/security-bootstrapper-postgres/secrets-token.json`.
 2. Display (GET) the postgres credentials from the `security-bootstrapper-postgres` secret store by using the OpenBao API:
    ```
-   curl -s -H 'X-Vault-Token: <OpenBao-Root-Token>' http://localhost:8200/v1/secret/edgex/security-bootstrapper-postgres/postgres | python -m json.tool
+   curl -s -H 'X-Vault-Token: <OpenBao-Token>' http://localhost:8200/v1/secret/edgex/security-bootstrapper-postgres/postgres | python -m json.tool
    {
        "request_id": "e4e8f2e2-3185-6955-92ed-be725c3387fc",
        "lease_id": "",


### PR DESCRIPTION
Relates to #1410. Add the client_token instruction to retrieve postgres credential.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
