### PR TITLE
feat: Update default event retention duration to 168h

### DIFF
--- a/docs_src/microservices/core/data/Configuration.md
+++ b/docs_src/microservices/core/data/Configuration.md
@@ -51,7 +51,7 @@ Below are only the additional settings and sections that are specific to Core Da
 | Interval|10m|Purging interval defines when the database should be rid of events above the MaxCap.|
 | DefaultMaxCap|-1|The default maximum capacity defines where the high watermark of events should be detected for purging the amount of the event to the minimum capacity. The default value is `-1` to disable this feature.|
 | DefaultMinCap|1|The default minimum capacity defines where the total count of event should be kept during purging. The default value is `1`. Be careful to use `minCap`, since the database uses offset to count the rows, the value becomes larger, and the database needs more time to count the rows.|
-| DefaultDuration|720h|The default duration to keep the event, the default value is `"720h"`.|
+| DefaultDuration|168h|The default duration to keep the event, the default value is `"168h"`.|
 
 ## V3 Configuration Migration Guide
 No configuration updated

--- a/docs_src/microservices/core/data/details/DataRetention.md
+++ b/docs_src/microservices/core/data/details/DataRetention.md
@@ -42,13 +42,13 @@ Retention:
   Interval: "10m"
   DefaultMaxCap: -1
   DefaultMinCap: 1      
-  DefaultDuration: "720h"
+  DefaultDuration: "168h"
 ```
 
 * `Interval` default value is "10m", you can disable the event purging process by using "0s". Valid time units are "s", "m", "h", e.g., "1.5h" or "2h45m".
 * `DefaultMaxCap` is the default maximum events capacity, and the default value is -1.
 * `DefaultMinCap` is the default minimum events capacity, and the default value is 1. Be careful to use `minCap`, since the database uses offset to count the rows, the value becomes larger, and the database needs more time to count the rows.
-* `DefaultDuration` is the default duration to keep the event, the default value is "720h".
+* `DefaultDuration` is the default duration to keep the event, the default value is "168h".
 
 ## Usage
 


### PR DESCRIPTION
Update default event retention duration to 168h.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
