### PR TITLE
feat: Add doc for secretstore-setup regen token feature

### DIFF
--- a/docs_src/security/Ch-SecretStoreSetup.md
+++ b/docs_src/security/Ch-SecretStoreSetup.md
@@ -1,0 +1,18 @@
+# Secret Store Setup
+
+## Introduction
+
+In an EdgeX deployment, the security-secretstore-setup service initializes the secret store, generates tokens for each EdgeX service to access it, and securely stores their respective secrets and credentials within the secret store.
+
+The secret store token is periodically renewed to maintain seamless access to the secret store for each service. However, renewal occurs only if the corresponding EdgeX service is actively running and responsive.
+If the secret store token expires, the only way to regenerate it is by restarting the security-secretstore-setup service for the respective EdgeX service.
+
+Starting in EdgeX 4.0, the security-secretstore-setup service transitions to a long running service, introducing a new **regenerate token** REST API that enables the regeneration of secret store tokens for EdgeX services upon expiration.
+If an EdgeX service's secret store token expires, restarting the service will automatically trigger the **regenerate token** API, allowing the service to successfully regain access to the secret store.
+
+!!! edgey "EdgeX 4.0"
+    security-secretstore-setup **regenerate token** API is new for EdgeX 4.0.
+
+## Secret Store Setup - API Reference
+
+<swagger-ui src="https://raw.githubusercontent.com/edgexfoundry/edgex-go/{{edgexversion}}/openapi/security-secretstore-setup.yaml"/>

--- a/docs_src/security/security-file-token-provider.1.md
+++ b/docs_src/security/security-file-token-provider.1.md
@@ -1,6 +1,6 @@
 # NAME
 
-security-file-token-provider -- Generate Vault tokens for EdgeX services
+security-file-token-provider -- Generate OpenBao tokens for EdgeX services
 
 # SYNOPSIS
 
@@ -12,13 +12,13 @@ security-file-token-provider \[-h\--configDir \<configDir\>\]
 
 # DESCRIPTION
 
-security-file-token-provider generates per-service Vault tokens for
-EdgeX services so that they can make authenticated connections to Vault
+security-file-token-provider generates per-service OpenBao tokens for
+EdgeX services so that they can make authenticated connections to OpenBao
 to retrieve application secrets. security-file-token-provider implements
 a generic secret seeding mechanism based on pre-created files and is
 designed for maximum portability. security-file-token-provider takes a
 configuration file that specifies the services for which tokens shall be
-generated and the Vault access policy that shall be applied to those
+generated and the OpenBao access policy that shall be applied to those
 tokens. security-file-token-provider assumes that there is some
 underlying protection mechanism that will be used to prevent EdgeX
 services from reading each other's tokens.
@@ -33,19 +33,30 @@ services from reading each other's tokens.
 >
 > :   Look in this directory for configuration.yaml instead.
 >
-> -p, \--profile \<name\>
->
-> :   Indicate configuration profile other than default
 
 !!! edgey "EdgeX 3.0"
     The `-c, --confdir` command line option is replaced by `-cd, --configDir` in EdgeX 3.0.
+
+# SUBCOMMANDS
+
+* **createToken**
+
+  Generate a new secret store token for the specified entity id.
+  Requires additional arguments:
+
+    * **--entityId** _id_ (required)
+
+      The OpenBao entity ID to be linked with the generated OpenBao token.
+
+!!! edgey "EdgeX 4.0"
+    The **createToken** subcommand is new for EdgeX 4.0.
 
 # FILES
 
 ## configuration.yaml
 
-This file specifies the TCP/IP location of the Vault service and
-parameters used for Vault token generation.
+This file specifies the TCP/IP location of the OpenBao service and
+parameters used for OpenBao token generation.
 
     SecretService:
       Scheme: "https"
@@ -53,14 +64,14 @@ parameters used for Vault token generation.
       Port: 8200 
 
     TokenFileProvider:
-      PrivilegedTokenPath: "/run/edgex/secrets/security-file-token-provider/secrets-token.json"
+      PrivilegedTokenPath: "/run/edgex/secrets/tokenprovider/secrets-token.json"
       ConfigFile: "token-config.json"
       OutputDir: "/run/edgex/secrets/"
       OutputFilename: "secrets-token.json"
 
 ## secrets-token.json
 
-This file contains a token used to authenticate to Vault. The filename
+This file contains a token used to authenticate to OpenBao. The filename
 is customizable via *OutputFilename*.
 
     {
@@ -136,31 +147,63 @@ For example:
 `/run/edgex/secrets/edgex-security-proxy-setup/secrets-token.json`
 
 For each "service-name" in `{ConfigFile}`, a matching directory is
-created under `{OutputDir}` and the corresponding Vault token is stored
+created under `{OutputDir}` and the corresponding OpenBao token is stored
 as `{OutputFilename}`. This file contains the authorization token
 generated to allow the indicated EdgeX service to retrieve its secrets.
 
 # PREREQUISITES
 
-`PrivilegedTokenPath` points to a non-expired Vault token that the
+`PrivilegedTokenPath` points to a non-expired OpenBao token that the
 security-file-token-provider will use to install policies and create
 per-service tokens. It will create policies with the naming convention
 `"edgex-service-service-name"` where `service-name` comes from JSON keys
-in the configuration file and the Vault policy will be configured to
+in the configuration file and the OpenBao policy will be configured to
 allow creation and modification of policies using this naming
 convention. This token must have the following policy
 (`edgex-privileged-token-creator`) configured.
 
-    path "auth/token/create" {
-      capabilities = ["create", "update", "sudo"]
+    path "identity/entity/name" {
+        capabilities = ["list"]
     }
 
-    path "auth/token/create-orphan" {
-      capabilities = ["create", "update", "sudo"]
+    path "identity/entity/name/*" {
+        capabilities = ["create", "update", "read"]
+    }
+
+    path "identity/entity/id/*" {
+        capabilities = ["read"]
+    }
+    
+    path "identity/entity-alias" {
+        capabilities = ["create", "update"]
+    }
+    
+    path "identity/oidc/role" {
+        capabilities = ["list"]
+    }
+    
+    path "identity/oidc/role/*" {
+        capabilities = ["create", "update"]
+    }
+    
+    path "auth/userpass/users/*" {
+        capabilities = ["create", "update"]
     }
 
     path "auth/token/create/*" {
       capabilities = ["create", "update", "sudo"]
+    }
+
+    path "auth/token/roles" {
+        capabilities = ["list"]
+    }
+    
+    path "auth/token/roles/*" {
+        capabilities = ["create", "update"]
+    }
+    
+    path "sys/auth" {
+        capabilities = ["read"]
     }
 
     path "sys/policies/acl/edgex-service-*"
@@ -175,4 +218,4 @@ convention. This token must have the following policy
 
 # AUTHOR
 
-EdgeX Foundry \<<info@edgexfoundry.org>\>
+EdgeX Foundry <<info@edgexfoundry.org>\>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -337,6 +337,7 @@ nav:
     - Security:
       - Security Services: security/Ch-Security.md
       - security/Ch-SecretStore.md
+      - security/Ch-SecretStoreSetup.md
       - security/Ch-Authenticating.md
       - security/Ch-SecretProviderApi.md
       - security/Ch-APIGateway.md


### PR DESCRIPTION
Fixes #1425. Add doc for secretstore-setup regen token feature.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
