### PR TITLE
fix: Add more description about EnableNameFieldEscape config

### DIFF
--- a/docs_src/microservices/configuration/CommonConfiguration.md
+++ b/docs_src/microservices/configuration/CommonConfiguration.md
@@ -70,7 +70,14 @@ The tables in each of the tabs below document configuration properties that are 
     |MaxResultCount|1024*|Read data limit per invocation. *Default value is for core/support services. Application and Device services do not implement this setting. |
     |MaxRequestSize|0|Defines the maximum size of http request body in kilbytes. 0 represents default to system max.|
     |RequestTimeout         |5s                          | Specifies a timeout duration for handling requests |
-    |EnableNameFieldEscape|false|The name field escape could allow the system to use special or Chinese characters in the different name fields, including device, profile, and so on.  If the EnableNameFieldEscape is false, some special characters might cause system error. If EnableNameFieldEscape is true, the client of event or command message bus API clients have to escape the name to subscribe the topics, for example, if the device name is `test-device`, the escaped device name should be `test%2Ddevice`, and the event topic is similar to `edgex/events/device/device%2Dvirtual/test%2Dprofile/test%2Ddevice/test%2Dresource`.|
+    |EnableNameFieldEscape|false|The name field escape could allow the system to use special or Chinese characters in the different name fields, including device, profile, and so on.  If the EnableNameFieldEscape is false, some special characters might cause system error. If EnableNameFieldEscape is true, the client of event or command message bus API clients have to escape the name to subscribe the topics.|
+    
+    !!! note
+        While the `EnableNameFieldEscape` configuration is set to true, the message bus API clients have to escape the URI, MQTT and Regex reserved charaters in the name to subscribe the topics.
+        For example, if the device name is `test-device`, the escaped device name should be `test%2Ddevice`, and the event topic is similar to `edgex/events/device/device%2Dvirtual/test%2Dprofile/test%2Ddevice/test%2Dresource`.
+        
+        Please refer to [Percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding), [Regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#escaping) and [MQTT Topics and Wildcards](https://www.emqx.com/en/blog/advanced-features-of-mqtt-topics#mqtt-wildcards) for detailed information on reserved characters in percent-encoding, regular expressions, and MQTT topics.
+
 === "Service.CORSConfiguration"
     |Property|Default Value|Description|
     |---|---|---|

--- a/docs_src/microservices/configuration/CommonConfiguration.md
+++ b/docs_src/microservices/configuration/CommonConfiguration.md
@@ -70,7 +70,7 @@ The tables in each of the tabs below document configuration properties that are 
     |MaxResultCount|1024*|Read data limit per invocation. *Default value is for core/support services. Application and Device services do not implement this setting. |
     |MaxRequestSize|0|Defines the maximum size of http request body in kilbytes. 0 represents default to system max.|
     |RequestTimeout         |5s                          | Specifies a timeout duration for handling requests |
-    |EnableNameFieldEscape|false|The name field escape could allow the system to use special or Chinese characters in the different name fields, including device, profile, and so on.  If the EnableNameFieldEscape is false, some special characters might cause system error. If EnableNameFieldEscape is true, the client of event or command message bus API clients have to escape the name to subscribe the topics.|
+    |EnableNameFieldEscape|false|The name field escape could allow the system to use special or Chinese characters in the different name fields, including device, profile, and so on. If the EnableNameFieldEscape is set to false, some special characters might cause system error. If EnableNameFieldEscape is set to true, the client of event or command message bus API clients have to escape the name to subscribe the topics.|
     
     !!! note
         While the `EnableNameFieldEscape` configuration is set to true, the message bus API clients have to escape the URI, MQTT and Regex reserved charaters in the name to subscribe the topics.


### PR DESCRIPTION
Relates to #1428. Add more description about EnableNameFieldEscape service config.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
