### PR TITLE
fix: Security upgrade python from 3.10-slim to 3.13.3-slim

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -15,7 +15,7 @@
 
 # Useful for local testing
 
-FROM python:3.10-slim
+FROM python:3.13.3-slim
 
 RUN pip install mkdocs \
     "mkdocs-material==9.1.19" \


### PR DESCRIPTION
Security upgrade python from 3.10-slim to 3.13.3-slim


<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
