### PR TITLE
feat: Add docs for the new SendChangedReadingsOnly config

### DIFF
--- a/docs_src/microservices/device/Configuration.md
+++ b/docs_src/microservices/device/Configuration.md
@@ -60,6 +60,7 @@ Please refer to the general [Common Configuration documentation](../configuratio
 |DeviceDownTimeout|0|If set, an interval in seconds after which a device which has been automatically set DOWN will be re-tried to see if it is accessible again|
 |Discovery/Enabled|false|Controls whether device discovery is enabled|
 |Discovery/Interval|30s|Interval between automatic discovery runs. Zero means do not run discovery automatically|
+|AutoEvents/SendChangedReadingsOnly|false|If set to true, only updated readings compared to the previous event are included in the generated auto event|
 === "MaxEventSize*"
 |Property|Default Value|Description|    
 |---|---|---|

--- a/docs_src/microservices/device/details/AutoEvents.md
+++ b/docs_src/microservices/device/details/AutoEvents.md
@@ -15,7 +15,7 @@ From the diagram above, <code>Autoevents</code> is used to define how often even
 - **interval**: a string indicating the time to wait between reading, expressed as an integer followed by units of ms, s, m or h.
 - **onChange**: a boolean: if set to true, only generate new events if one or more of the contained readings has changed since the last event.
 !!! note
-    If `Device.AutoEvents.SendChangedReadingsOnly` configuration is set to true, only updated readings compared to the previous event are included in the generated auto event.
+    With both the `onChange` field and the `Device.AutoEvents.SendChangedReadingsOnly` configuration are set to true, the generated auto event includes only readings that have changed since the previous event.
 - **onChangeThreshold**: a float64 indicating any changed value that exceeds the threshold shall be generated new event if `onChange` is true, this feature only applies to the numeric reading. Available value types are `Uint8`, `Uint16`, `Uint32`, `Uint64`, `Int8`, `Int16`, `Int32`, `Int64`, `Float32`, `Float64`. For example, if the current value is 0.03, the previous value is 0.05, and the threshold is 0.01, then | 0.03 - 0.05 | > 0.01, the device service should generate a new event.
 
 ## Example and Usage

--- a/docs_src/microservices/device/details/AutoEvents.md
+++ b/docs_src/microservices/device/details/AutoEvents.md
@@ -14,6 +14,8 @@ From the diagram above, <code>Autoevents</code> is used to define how often even
 - **sourceName**: the name of a deviceResource or deviceCommand indicating what to read.
 - **interval**: a string indicating the time to wait between reading, expressed as an integer followed by units of ms, s, m or h.
 - **onChange**: a boolean: if set to true, only generate new events if one or more of the contained readings has changed since the last event.
+!!! note
+    If `Device.AutoEvents.SendChangedReadingsOnly` configuration is set to true, only updated readings compared to the previous event are included in the generated auto event.
 - **onChangeThreshold**: a float64 indicating any changed value that exceeds the threshold shall be generated new event if `onChange` is true, this feature only applies to the numeric reading. Available value types are `Uint8`, `Uint16`, `Uint32`, `Uint64`, `Int8`, `Int16`, `Int32`, `Int64`, `Float32`, `Float64`. For example, if the current value is 0.03, the previous value is 0.05, and the threshold is 0.01, then | 0.03 - 0.05 | > 0.01, the device service should generate a new event.
 
 ## Example and Usage


### PR DESCRIPTION
Resolves #1468. Add docs for the new SendChangedReadingsOnly config.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
