### PR TITLE
fix: Remove obsolete mlock information for OpenBao running in rootless

### DIFF
--- a/docs_src/security/Rootless-Docker.md
+++ b/docs_src/security/Rootless-Docker.md
@@ -19,22 +19,14 @@ There are four requirements to run Edgex in a rootless Docker environment:
     a rootless docker environment. You will find that you can now run docker commands without sudo,
     and that the docker socket is now located in /run/user/{USERID}/docker.sock instead of /var/run/docker.sock.
 
-2. Memory locking must be disabled for the Vault container:
-
-    Vault locks memory by default to disable swapping to disk. While this is a more secure, it requires
-    access to the mlock() sys call which requires root privileges.
-    In order for us to run Vault in a rootless environment, we need to disable this feature.
-    This is done by setting memory limits in the compose file and by adding `disable_mlock = true` to the local secret store config.
-    More can be found at the [Vault documentation](https://www.vaultproject.io/docs/configuration/storage/file).
-
-3. Docker socket volume mappings must be mapped to non-root user docker installation location:
+2. Docker socket volume mappings must be mapped to non-root user docker installation location:
 
     In a default (rootful) docker installation, the docker socket is mapped to /var/run/docker.sock.
     When the docker installation is configured to be a rootless environment the location of the docker socket
     is moved to /run/user/{USERID}/docker.sock. The portainer and security-spire-agent containers both map in the
     docker socket to manage containers, so must be remapped to the new location.
 
-4.  Serial port permissions need to be set to allow non-root user access to the serial port:
+3. Serial port permissions need to be set to allow non-root user access to the serial port:
 
     A container running in a rootful docker environment can easily mount in serial ports on the host system,
     but this is not the case for a rootless docker environment. Serial ports are owned by the root user,
@@ -55,11 +47,8 @@ Please refer to the [Docker Rootless Mode](https://docs.docker.com/engine/securi
 2.  In the edgex-compose directory, run `make run`, and the rest has already been resolved for you.
 
 !!! Note
-    By default Vault has been configured to run in a rootless environment.
-    The compose entries for Vault's memory limits are automatically resolved for the host system when
+    By default OpenBao has been configured to run in a rootless environment.
+    The compose entries for OpenBao's memory limits are automatically resolved for the host system when
     you run `make build` in the `compose-builder` directory and written statically to the generated compose files.
     The compose entries for the docker socket volume mappings are automatically resolved for the
     host system when you add the `portainer` or `delayed-start` args to the `make run` command in the root edgex-compose directory.
-
-
-


### PR DESCRIPTION
fixes https://github.com/edgexfoundry/edgex-docs/issues/1483

Starting with version 2.0.0, OpenBao removed mlock functionality entirely and made the disable_mlock configuration option obsolete. So updating the edgex-docx to remove obsolete mlock information.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
