### PR TITLE
feat: Update support-scheduler doc for activeYearlyTimeWindow

### DIFF
--- a/docs_src/microservices/support/scheduler/GettingStarted.md
+++ b/docs_src/microservices/support/scheduler/GettingStarted.md
@@ -74,10 +74,14 @@ Examples of schedule action include:
 ### ScheduleDefinition
 A schedule definition specifies an interval (type **INTERVAL**) or a crontab expression (type **CRON**) for a scheduleJob to be triggered at a specific time.
 
-Two optional fields are available for the schedule definition:
+Three optional fields are available for the schedule definition:
 
 1. **startTimestamp**: The start Unix timestamp of the schedule job, in milliseconds.
 2. **endTimestamp**: The end Unix timestamp of the schedule job, in milliseconds.
+3. **activeYearlyTimeWindow**: A recurring yearly active period, given as a start and end month/day. The job only runs on dates within this period each year and is skipped outside it. When omitted, the job runs on every trigger within its lifetime. If the start (month/day) is later than the end, the window is year-crossing, e.g. Nov 15 to Feb 10 keeps the job active every winter. This field works with both INTERVAL and CRON.
+
+    !!! edgey "EdgeX 4.1"
+        The `activeYearlyTimeWindow` field is available since EdgeX 4.1.
 
 Examples of schedule definition include:
 
@@ -95,6 +99,19 @@ Examples of schedule definition include:
     {
         "type": "CRON",
         "crontab": "CRON_TZ=Asia/Taipei 0 0 0 * * *"
+    }
+    ```
+3. **activeYearlyTimeWindow**: A schedule job will be triggered every hour, but only during winter (November 1 to February 28) each year.
+    ```
+    {
+        "type": "INTERVAL",
+        "interval": "1h",
+        "activeYearlyTimeWindow": {
+            "startMonth": 11,
+            "startDay": 1,
+            "endMonth": 2,
+            "endDay": 28
+        }
     }
     ```
 !!! note


### PR DESCRIPTION
Update support-scheduler doc for activeYearlyTimeWindow. A recurring yearly active period, given as a start and end month/day. The job only runs on dates within this period each year and is skipped outside it. When omitted, the job runs on every trigger within its lifetime.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-docs/blob/main/.github/Contributing.md 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Changes have been rendered and validated locally using mkdocs-material (see edgex-docs README)
